### PR TITLE
Refactored Backend to Polyglot Architecture Pattern

### DIFF
--- a/src/Schuly.API/Controllers/AbsencesController.cs
+++ b/src/Schuly.API/Controllers/AbsencesController.cs
@@ -10,58 +10,66 @@ namespace Schuly.API.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize]
-    public class AbsencesController : ControllerBase
+    public class AbsencesController(IMediator mediator) : ControllerBase
     {
-        private readonly IMediator _mediator;
-        public AbsencesController(IMediator mediator)
-        {
-            _mediator = mediator;
-        }
-
         [HttpGet]
         [ProducesResponseType(typeof(List<AbsenceDto>), StatusCodes.Status200OK)]
-        public async Task<ActionResult<List<AbsenceDto>>> GetAbsences()
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetAbsences(CancellationToken cancellationToken)
         {
-            return Ok(await _mediator.Send(new GetAbsencesQuery(), HttpContext.RequestAborted));
+            var result = await mediator.Send(new GetAbsencesQuery(), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpGet("search")]
         [ProducesResponseType(typeof(AbsenceDto), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult<AbsenceDto>> GetAbsence([FromQuery] GetAbsenceQuery getAbsence)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetAbsence([FromQuery] long absenceId, CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(getAbsence, HttpContext.RequestAborted);
-            if (result == null)
-                return NotFound();
-            return Ok(result);
+            var result = await mediator.Send(new GetAbsenceQuery(absenceId), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpPost]
-        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> CreateAbsence(CreateAbsenceCommand createAbsenceCommand)
+        public async Task<IActionResult> CreateAbsence([FromBody] CreateAbsenceCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(createAbsenceCommand, HttpContext.RequestAborted);
-            return Created();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
         [HttpPut]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> UpdateAbsence(UpdateAbsenceCommand updateAbsenceCommand)
+        public async Task<IActionResult> UpdateAbsence([FromBody] UpdateAbsenceCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(updateAbsenceCommand, HttpContext.RequestAborted);
-            return Ok();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
-        [HttpDelete]
+        [HttpDelete("{id:long}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> RemoveAbsence(RemoveAbsenceCommand removeAbsence)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> RemoveAbsence(long id, CancellationToken cancellationToken)
         {
-            await _mediator.Send(removeAbsence, HttpContext.RequestAborted);
-            return NoContent();
+            var result = await mediator.Send(new RemoveAbsenceCommand(id), cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
     }
 }

--- a/src/Schuly.API/Controllers/AgendasController.cs
+++ b/src/Schuly.API/Controllers/AgendasController.cs
@@ -10,58 +10,66 @@ namespace Schuly.API.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize]
-    public class AgendasController : ControllerBase
+    public class AgendasController(IMediator mediator) : ControllerBase
     {
-        private readonly IMediator _mediator;
-        public AgendasController(IMediator mediator)
-        {
-            _mediator = mediator;
-        }
-
         [HttpGet]
         [ProducesResponseType(typeof(List<AgendaEntryDto>), StatusCodes.Status200OK)]
-        public async Task<ActionResult<List<AgendaEntryDto>>> GetAgendas()
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetAgendas(CancellationToken cancellationToken)
         {
-            return Ok(await _mediator.Send(new GetAgendasQuery(), HttpContext.RequestAborted));
+            var result = await mediator.Send(new GetAgendasQuery(), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpGet("search")]
         [ProducesResponseType(typeof(AgendaEntryDto), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult<AgendaEntryDto>> GetAgenda([FromQuery] GetAgendaQuery getAgenda)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetAgenda([FromQuery] long agendaEntryId, CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(getAgenda, HttpContext.RequestAborted);
-            if (result == null)
-                return NotFound();
-            return Ok(result);
+            var result = await mediator.Send(new GetAgendaQuery(agendaEntryId), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpPost]
-        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> CreateEntry(CreateAgendaEntryCommand createAgendaEntry)
+        public async Task<IActionResult> CreateEntry([FromBody] CreateAgendaEntryCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(createAgendaEntry, HttpContext.RequestAborted);
-            return Created();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
         [HttpPut]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> UpdateEntry(UpdateAgendaEntryCommand updateAgendaEntry)
+        public async Task<IActionResult> UpdateEntry([FromBody] UpdateAgendaEntryCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(updateAgendaEntry, HttpContext.RequestAborted);
-            return Ok();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
-        [HttpDelete]
+        [HttpDelete("{id:long}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> DeleteEntry(DeleteAgendaEntryCommand deleteAgendaEntry)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> DeleteEntry(long id, CancellationToken cancellationToken)
         {
-            await _mediator.Send(deleteAgendaEntry, HttpContext.RequestAborted);
-            return NoContent();
+            var result = await mediator.Send(new DeleteAgendaEntryCommand(id), cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
     }
 }

--- a/src/Schuly.API/Controllers/ApplicationUsersController.cs
+++ b/src/Schuly.API/Controllers/ApplicationUsersController.cs
@@ -10,81 +10,66 @@ namespace Schuly.API.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize]
-    public class ApplicationUsersController : ControllerBase
+    public class ApplicationUsersController(IMediator mediator) : ControllerBase
     {
-        private readonly IMediator _mediator;
-
-        public ApplicationUsersController(IMediator mediator)
-        {
-            _mediator = mediator;
-        }
-
-        [HttpGet("{id}")]
+        [HttpGet("{id:guid}")]
         [ProducesResponseType(typeof(ApplicationUserDto), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult<ApplicationUserDto>> GetApplicationUser(Guid id)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetApplicationUser(Guid id, CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(
-                new GetApplicationUserQuery { ApplicationUserId = id },
-                HttpContext.RequestAborted);
+            var result = await mediator.Send(new GetApplicationUserQuery(id), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
 
-            if (result == null)
-                return NotFound();
-
-            return Ok(result);
+            return BadRequest(result.Error);
         }
 
         [HttpGet]
         [ProducesResponseType(typeof(List<ApplicationUserDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult<List<ApplicationUserDto>>> GetApplicationUsers()
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetApplicationUsers(CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(
-                new GetApplicationUsersQuery(),
-                HttpContext.RequestAborted);
+            var result = await mediator.Send(new GetApplicationUsersQuery(), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
 
-            return Ok(result);
+            return BadRequest(result.Error);
         }
 
         [HttpPost]
-        [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(Guid), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult<Guid>> CreateApplicationUser(CreateApplicationUserCommand command)
+        public async Task<IActionResult> CreateApplicationUser([FromBody] CreateApplicationUserCommand command, CancellationToken cancellationToken)
         {
-            var id = await _mediator.Send(command, HttpContext.RequestAborted);
-            return CreatedAtAction(nameof(GetApplicationUser), new { id }, id);
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpPut]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult> UpdateApplicationUser(UpdateApplicationUserCommand command)
+        public async Task<IActionResult> UpdateApplicationUser([FromBody] UpdateApplicationUserCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(command, HttpContext.RequestAborted);
-            return Ok();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
-        [HttpDelete("{id}")]
+        [HttpDelete("{id:guid}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult> DeleteApplicationUser(Guid id)
+        public async Task<IActionResult> DeleteApplicationUser(Guid id, CancellationToken cancellationToken)
         {
-            await _mediator.Send(
-                new DeleteApplicationUserCommand { ApplicationUserId = id },
-                HttpContext.RequestAborted);
+            var result = await mediator.Send(new DeleteApplicationUserCommand(id), cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
 
-            return NoContent();
+            return BadRequest(result.Error);
         }
     }
 }

--- a/src/Schuly.API/Controllers/AuthController.cs
+++ b/src/Schuly.API/Controllers/AuthController.cs
@@ -2,61 +2,52 @@ using Mediator;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Schuly.Application.Commands.User;
+using Schuly.Application.Dtos;
 using Schuly.Application.Queries.User;
 
 namespace Schuly.API.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class AuthController : ControllerBase
+    public class AuthController(IMediator mediator) : ControllerBase
     {
-        private readonly IMediator _mediator;
-
-        public AuthController(IMediator mediator)
-        {
-            _mediator = mediator;
-        }
-
         [HttpPost("register")]
         [AllowAnonymous]
-        public async Task<ActionResult<RegisterResponse>> Register([FromBody] RegisterCommand command)
+        [ProducesResponseType(typeof(LoginDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> Register([FromBody] RegisterCommand command, CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(command);
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
 
-            if (!result.Success)
-            {
-                return BadRequest(result);
-            }
-
-            return Ok(result);
+            return BadRequest(result.Error);
         }
 
         [HttpPost("login")]
         [AllowAnonymous]
-        public async Task<ActionResult<LoginResponse>> Login([FromBody] LoginCommand command)
+        [ProducesResponseType(typeof(LoginDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> Login([FromBody] LoginCommand command, CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(command);
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
 
-            if (!result.Success)
-            {
-                return Unauthorized(result);
-            }
-
-            return Ok(result);
+            return BadRequest(result.Error);
         }
 
         [HttpGet("me")]
         [Authorize]
-        public async Task<ActionResult<GetCurrentUserQuery>> GetCurrentUser()
+        [ProducesResponseType(typeof(UserDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetCurrentUser(CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(new GetCurrentUserQuery());
+            var result = await mediator.Send(new GetCurrentUserQuery(), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
 
-            if (result == null)
-            {
-                return Unauthorized();
-            }
-
-            return Ok(result);
+            return BadRequest(result.Error);
         }
     }
 }

--- a/src/Schuly.API/Controllers/ClassController.cs
+++ b/src/Schuly.API/Controllers/ClassController.cs
@@ -10,67 +10,78 @@ namespace Schuly.API.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize]
-    public class ClassController : ControllerBase
+    public class ClassController(IMediator mediator) : ControllerBase
     {
-        private readonly IMediator _mediator;
-        public ClassController(IMediator mediator)
-        {
-            _mediator = mediator;
-        }
-
         [HttpGet("search")]
         [ProducesResponseType(typeof(ClassDto), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult<ClassDto>> GetClass([FromQuery] GetClassQuery getClass)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetClass([FromQuery] Guid classId, CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(getClass, HttpContext.RequestAborted);
-            if (result == null)
-                return NotFound();
-            return Ok(result);
+            var result = await mediator.Send(new GetClassQuery(classId), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpGet]
         [ProducesResponseType(typeof(List<ClassDto>), StatusCodes.Status200OK)]
-        public async Task<ActionResult<List<ClassDto>>> GetClasses()
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetClasses(CancellationToken cancellationToken)
         {
-            return Ok(await _mediator.Send(new GetClasssQuery(), HttpContext.RequestAborted));
+            var result = await mediator.Send(new GetClassesQuery(), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpPost]
-        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> CreateClass(CreateClassCommand createClass)
+        public async Task<IActionResult> CreateClass([FromBody] CreateClassCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(createClass, HttpContext.RequestAborted);
-            return Created();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
         [HttpPost("enrol-student")]
-        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> EnrolStudent(EnrolStudentCommand enrolStudent)
+        public async Task<IActionResult> EnrolStudent([FromBody] EnrolStudentCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(enrolStudent, HttpContext.RequestAborted);
-            return Created();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
         [HttpPut]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> UpdateClass(UpdateClassCommand updateClass)
+        public async Task<IActionResult> UpdateClass([FromBody] UpdateClassCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(updateClass, HttpContext.RequestAborted);
-            return Ok();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
-        [HttpDelete]
+        [HttpDelete("{id:guid}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> DeleteClass(DeleteClassCommand deleteClass)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> DeleteClass(Guid id, CancellationToken cancellationToken)
         {
-            await _mediator.Send(deleteClass, HttpContext.RequestAborted);
-            return NoContent();
+            var result = await mediator.Send(new DeleteClassCommand(id), cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
     }
 }

--- a/src/Schuly.API/Controllers/ExamsController.cs
+++ b/src/Schuly.API/Controllers/ExamsController.cs
@@ -10,67 +10,78 @@ namespace Schuly.API.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize]
-    public class ExamsController : ControllerBase
+    public class ExamsController(IMediator mediator) : ControllerBase
     {
-        private readonly IMediator _mediator;
-        public ExamsController(IMediator mediator)
-        {
-            _mediator = mediator;
-        }
-
         [HttpGet("search")]
         [ProducesResponseType(typeof(ExamDto), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult<ExamDto>> GetExam([FromQuery] GetExamQuery getExam)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetExam([FromQuery] long examId, CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(getExam, HttpContext.RequestAborted);
-            if (result == null)
-                return NotFound();
-            return Ok(result);
+            var result = await mediator.Send(new GetExamQuery(examId), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpGet]
         [ProducesResponseType(typeof(List<ExamDto>), StatusCodes.Status200OK)]
-        public async Task<ActionResult<List<ExamDto>>> GetExams()
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetExams(CancellationToken cancellationToken)
         {
-            return Ok(await _mediator.Send(new GetExamsQuery(), HttpContext.RequestAborted));
+            var result = await mediator.Send(new GetExamsQuery(), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpPost]
-        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> AddExam(CreateExamCommand createExam)
+        public async Task<IActionResult> AddExam([FromBody] CreateExamCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(createExam, HttpContext.RequestAborted);
-            return Created();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
         [HttpPost("grade")]
-        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> AddGradeToExam(AddGradeToExamCommand addGradeToExam)
+        public async Task<IActionResult> AddGradeToExam([FromBody] AddGradeToExamCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(addGradeToExam, HttpContext.RequestAborted);
-            return Created();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
         [HttpPut]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> UpdateExam(UpdateExamCommand updateExam)
+        public async Task<IActionResult> UpdateExam([FromBody] UpdateExamCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(updateExam, HttpContext.RequestAborted);
-            return Ok();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
-        [HttpDelete]
+        [HttpDelete("{id:long}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> DeleteExam(DeleteExamCommand deleteExam)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> DeleteExam(long id, CancellationToken cancellationToken)
         {
-            await _mediator.Send(deleteExam, HttpContext.RequestAborted);
-            return NoContent();
+            var result = await mediator.Send(new DeleteExamCommand(id), cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
     }
 }

--- a/src/Schuly.API/Controllers/SchoolUsersController.cs
+++ b/src/Schuly.API/Controllers/SchoolUsersController.cs
@@ -10,80 +10,66 @@ namespace Schuly.API.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize]
-    public class SchoolUsersController : ControllerBase
+    public class SchoolUsersController(IMediator mediator) : ControllerBase
     {
-        private readonly IMediator _mediator;
-
-        public SchoolUsersController(IMediator mediator)
-        {
-            _mediator = mediator;
-        }
-
-        [HttpGet("{id}")]
+        [HttpGet("{id:long}")]
         [ProducesResponseType(typeof(SchoolUserDto), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult<SchoolUserDto>> GetSchoolUser(long id)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetSchoolUser(long id, CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(
-                new GetSchoolUserQuery { SchoolUserId = id },
-                HttpContext.RequestAborted);
+            var result = await mediator.Send(new GetSchoolUserQuery(id), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
 
-            if (result == null)
-                return NotFound();
-
-            return Ok(result);
+            return BadRequest(result.Error);
         }
 
         [HttpGet]
         [ProducesResponseType(typeof(List<SchoolUserDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult<List<SchoolUserDto>>> GetSchoolUsers([FromQuery] Guid? applicationUserId)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetSchoolUsers([FromQuery] Guid? applicationUserId, CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(
-                new GetSchoolUsersQuery { ApplicationUserId = applicationUserId },
-                HttpContext.RequestAborted);
+            var result = await mediator.Send(new GetSchoolUsersQuery(applicationUserId), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
 
-            return Ok(result);
+            return BadRequest(result.Error);
         }
 
         [HttpPost]
-        [ProducesResponseType(typeof(long), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(long), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult<long>> CreateSchoolUser(CreateSchoolUserCommand command)
+        public async Task<IActionResult> CreateSchoolUser([FromBody] CreateSchoolUserCommand command, CancellationToken cancellationToken)
         {
-            var id = await _mediator.Send(command, HttpContext.RequestAborted);
-            return CreatedAtAction(nameof(GetSchoolUser), new { id }, id);
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpPut]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult> UpdateSchoolUser(UpdateSchoolUserCommand command)
+        public async Task<IActionResult> UpdateSchoolUser([FromBody] UpdateSchoolUserCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(command, HttpContext.RequestAborted);
-            return Ok();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
-        [HttpDelete("{id}")]
+        [HttpDelete("{id:long}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult> DeleteSchoolUser(long id)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> DeleteSchoolUser(long id, CancellationToken cancellationToken)
         {
-            await _mediator.Send(
-                new DeleteSchoolUserCommand { SchoolUserId = id },
-                HttpContext.RequestAborted);
+            var result = await mediator.Send(new DeleteSchoolUserCommand(id), cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
 
-            return NoContent();
+            return BadRequest(result.Error);
         }
     }
 }

--- a/src/Schuly.API/Controllers/SchoolsController.cs
+++ b/src/Schuly.API/Controllers/SchoolsController.cs
@@ -10,92 +10,78 @@ namespace Schuly.API.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize]
-    public class SchoolsController : ControllerBase
+    public class SchoolsController(IMediator mediator) : ControllerBase
     {
-        private readonly IMediator _mediator;
-
-        public SchoolsController(IMediator mediator)
-        {
-            _mediator = mediator;
-        }
-
         [HttpGet]
         [ProducesResponseType(typeof(List<SchoolDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult<List<SchoolDto>>> GetSchools()
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetSchools(CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(
-                new GetSchoolsQuery(),
-                HttpContext.RequestAborted);
+            var result = await mediator.Send(new GetSchoolsQuery(), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
 
-            return Ok(result);
+            return BadRequest(result.Error);
         }
 
         [HttpGet("my-schools")]
         [ProducesResponseType(typeof(List<SchoolDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        public async Task<ActionResult<List<SchoolDto>>> GetMySchools()
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetMySchools(CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(
-                new GetMySchoolsQuery(),
-                HttpContext.RequestAborted);
+            var result = await mediator.Send(new GetMySchoolsQuery(), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
 
-            return Ok(result);
+            return BadRequest(result.Error);
         }
 
-        [HttpGet("{id}")]
+        [HttpGet("{id:long}")]
         [ProducesResponseType(typeof(SchoolDto), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        public async Task<ActionResult<SchoolDto>> GetSchool(long id)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetSchool(long id, CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(
-                new GetSchoolQuery { SchoolId = id },
-                HttpContext.RequestAborted);
+            var result = await mediator.Send(new GetSchoolQuery(id), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
 
-            if (result == null)
-                return NotFound();
-
-            return Ok(result);
+            return BadRequest(result.Error);
         }
 
         [HttpPost]
-        [ProducesResponseType(typeof(long), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(long), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult<long>> CreateSchool(CreateSchoolCommand command)
+        public async Task<IActionResult> CreateSchool([FromBody] CreateSchoolCommand command, CancellationToken cancellationToken)
         {
-            var id = await _mediator.Send(command, HttpContext.RequestAborted);
-            return CreatedAtAction(nameof(GetSchool), new { id }, id);
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpPut]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult> UpdateSchool(UpdateSchoolCommand command)
+        public async Task<IActionResult> UpdateSchool([FromBody] UpdateSchoolCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(command, HttpContext.RequestAborted);
-            return Ok();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
-        [HttpDelete("{id}")]
+        [HttpDelete("{id:long}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<ActionResult> DeleteSchool(long id)
+        public async Task<IActionResult> DeleteSchool(long id, CancellationToken cancellationToken)
         {
-            await _mediator.Send(
-                new DeleteSchoolCommand { Id = id },
-                HttpContext.RequestAborted);
+            var result = await mediator.Send(new DeleteSchoolCommand(id), cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
 
-            return NoContent();
+            return BadRequest(result.Error);
         }
     }
 }

--- a/src/Schuly.API/Controllers/UsersController.cs
+++ b/src/Schuly.API/Controllers/UsersController.cs
@@ -10,70 +10,66 @@ namespace Schuly.API.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize]
-    public class UsersController : ControllerBase
+    public class UsersController(IMediator mediator) : ControllerBase
     {
-        private readonly IMediator _mediator;
-        public UsersController(IMediator mediator)
-        {
-            _mediator = mediator;
-        }
-
-        [HttpPost("login")]
-        [AllowAnonymous]
-        [ProducesResponseType(typeof(LoginResponse), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        public async Task<ActionResult<LoginResponse>> Login(LoginCommand loginCommand)
-        {
-            var result = await _mediator.Send(loginCommand, HttpContext.RequestAborted);
-            if (!result.Success)
-                return Unauthorized(result);
-            return Ok(result);
-        }
-
         [HttpGet("search")]
         [ProducesResponseType(typeof(UserDto), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult<UserDto>> GetUser([FromQuery] GetUserQuery getUser)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetUser([FromQuery] Guid userId, CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(getUser, HttpContext.RequestAborted);
-            if (result == null)
-                return NotFound();
-            return Ok(result);
+            var result = await mediator.Send(new GetUserQuery(userId), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpGet]
         [ProducesResponseType(typeof(List<UserDto>), StatusCodes.Status200OK)]
-        public async Task<ActionResult<List<UserDto>>> GetUsers()
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetUsers(CancellationToken cancellationToken)
         {
-            return Ok(await _mediator.Send(new GetUsersQuery(), HttpContext.RequestAborted));
+            var result = await mediator.Send(new GetUsersQuery(), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
         }
 
         [HttpPost]
-        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> CreateUser(CreateUserCommand createUser)
+        public async Task<IActionResult> CreateUser([FromBody] CreateUserCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(createUser, HttpContext.RequestAborted);
-            return Created();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
         [HttpPut]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> UpdateUser(UpdateUserCommand updateUser)
+        public async Task<IActionResult> UpdateUser([FromBody] UpdateUserCommand command, CancellationToken cancellationToken)
         {
-            await _mediator.Send(updateUser, HttpContext.RequestAborted);
-            return Ok();
+            var result = await mediator.Send(command, cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
 
-        [HttpDelete]
+        [HttpDelete("{id:guid}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> DeleteUser(DeleteUserCommand deleteUser)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> DeleteUser(Guid id, CancellationToken cancellationToken)
         {
-            await _mediator.Send(deleteUser, HttpContext.RequestAborted);
-            return NoContent();
+            var result = await mediator.Send(new DeleteUserCommand(id), cancellationToken);
+            if (result.IsSuccess)
+                return NoContent();
+
+            return BadRequest(result.Error);
         }
     }
 }

--- a/src/Schuly.API/Program.cs
+++ b/src/Schuly.API/Program.cs
@@ -1,7 +1,7 @@
 using Mediator;
-using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Authorization;
 using Schuly.Application.Configuration;
 using Schuly.Application.Queries.User;
 using Schuly.Application.Services;
@@ -9,32 +9,19 @@ using Schuly.Application.Services.Interfaces;
 using Schuly.Infrastructure;
 using System.Text.Json.Serialization;
 
-[assembly: MediatorOptions(ServiceLifetime = ServiceLifetime.Scoped)]
-
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
-builder.Services.Configure<JsonOptions>(options =>
-{
-    options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
-});
+builder.Services.AddMediator(options => { options.ServiceLifetime = ServiceLifetime.Scoped; });
 
-builder.Services.AddMediator((MediatorOptions options) =>
-{
-    options.Assemblies = [typeof(GetUserQuery)];
-    options.ServiceLifetime = ServiceLifetime.Scoped;
-});
-
-// Register JWT configuration factory
 builder.Services.AddSingleton<IJwtConfigurationFactory, JwtConfigurationFactory>();
 
-// Load JWT settings and validate
 var jwtFactory = builder.Services.BuildServiceProvider().GetRequiredService<IJwtConfigurationFactory>();
 var jwtSettings = jwtFactory.LoadJwtSettings();
 
-// Add authentication services with JWT configuration
 builder.Services.AddAuthentication(options =>
 {
     options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
@@ -44,17 +31,15 @@ builder.Services.AddAuthentication(options =>
 
 builder.Services.AddAuthorization();
 
-// Register application services
 builder.Services.AddScoped<IPasswordHashingService, PasswordHashingService>();
 builder.Services.AddScoped<ITokenGenerationService>(sp =>
     new TokenGenerationService(jwtSettings.SecretKey, jwtSettings.Issuer, jwtSettings.Audience, jwtSettings.ExpirationMinutes));
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IUserService, UserService>();
+builder.Services.AddScoped<IAuthorizationService, AuthorizationService>();
 
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 
-// Configure the DbContext
 builder.Services.AddDbContext<SchulyDbContext>(options =>
     options.UseNpgsql(
         builder.Configuration.GetConnectionString("SchulyDatabase"),
@@ -68,11 +53,9 @@ builder.Services.AddDbContext<SchulyDbContext>(options =>
 
 var app = builder.Build();
 
-// Applying database migrations
 using var scope = app.Services.CreateScope();
 scope.ServiceProvider.GetRequiredService<SchulyDbContext>().Database.Migrate();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();

--- a/src/Schuly.API/Schuly.API.csproj
+++ b/src/Schuly.API/Schuly.API.csproj
@@ -9,23 +9,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mediator.Abstractions" Version="3.0.1" />
-    <PackageReference Include="Mediator.SourceGenerator" Version="3.0.1">
+    <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.15.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.0.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Schuly.Application/Authorization/AuthorizationService.cs
+++ b/src/Schuly.Application/Authorization/AuthorizationService.cs
@@ -3,31 +3,31 @@ using Schuly.Domain.Enums;
 
 namespace Schuly.Application.Authorization
 {
-    public class AuthorizationService
+    public interface IAuthorizationService
     {
-        private readonly IUserService _userService;
+        Task CanAuthorizeAsync<T>(T obj) where T : notnull;
+    }
 
-        public AuthorizationService(IUserService userService)
-        {
-            _userService = userService;
-        }
-
-        public async Task CanAuthorizeAsync<T>(T obj) where T : notnull
+    public class AuthorizationService(IUserService userService) : IAuthorizationService
+    {
+        public Task CanAuthorizeAsync<T>(T obj) where T : notnull
         {
             if (obj is not IHasAuthorization authRequest)
-                return;
+                return Task.CompletedTask;
 
             var requiredRole = authRequest.GetRequiredRole();
-            var currentUserRole = _userService.GetCurrentUserRole();
+            var currentUserRole = userService.GetCurrentUserRole();
 
             if (!IsRoleAuthorized(currentUserRole, requiredRole))
             {
                 throw new UnauthorizedAccessException(
                     $"User with role {currentUserRole} is not authorized to perform this action. Required role: {requiredRole}.");
             }
+
+            return Task.CompletedTask;
         }
 
-        private bool IsRoleAuthorized(Roles userRole, Roles requiredRole)
+        private static bool IsRoleAuthorized(Roles userRole, Roles requiredRole)
         {
             if (userRole == Roles.Administrator)
                 return true;

--- a/src/Schuly.Application/Behaviors/AuthorizationBehavior.cs
+++ b/src/Schuly.Application/Behaviors/AuthorizationBehavior.cs
@@ -1,25 +1,16 @@
 using Mediator;
 using Schuly.Application.Authorization;
-using Schuly.Application.Services.Interfaces;
 
 namespace Schuly.Application.Behaviors
 {
-    public class AuthorizationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    public class AuthorizationBehavior<TRequest, TResponse>(IAuthorizationService authorizationService) : IPipelineBehavior<TRequest, TResponse>
         where TRequest : notnull, IMessage
     {
-        private readonly IUserService _userService;
-
-        public AuthorizationBehavior(IUserService userService)
-        {
-            _userService = userService;
-        }
-
         public async ValueTask<TResponse> Handle(
             TRequest request,
             MessageHandlerDelegate<TRequest, TResponse> next,
             CancellationToken cancellationToken)
         {
-            var authorizationService = new AuthorizationService(_userService);
             await authorizationService.CanAuthorizeAsync(request);
 
             return await next(request, cancellationToken);

--- a/src/Schuly.Application/Commands/Absence/CreateAbsenceCommand.cs
+++ b/src/Schuly.Application/Commands/Absence/CreateAbsenceCommand.cs
@@ -1,41 +1,28 @@
 using Mediator;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Absence
 {
-    public class CreateAbsenceCommand : IRequest
+    public record CreateAbsenceCommand(string Reason, AbsenceType Type, DateTime From, DateTime Until, Guid UserId) : ICommand<Result>;
+
+    public class CreateAbsenceCommandHandler(SchulyDbContext dbContext) : ICommandHandler<CreateAbsenceCommand, Result>
     {
-        public required string Reason { get; set; }
-        public required AbsenceType Type { get; set; }
-        public required DateTime From { get; set; }
-        public required DateTime Until { get; set; }
-        public required Guid UserId { get; set; }
-    }
-
-    public class CreateAbsenceCommandHandler : IRequestHandler<CreateAbsenceCommand>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public CreateAbsenceCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(CreateAbsenceCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<Unit> Handle(CreateAbsenceCommand request, CancellationToken cancellationToken)
-        {
-            await _dbContext.Absences.AddAsync(new Domain.Absence
+            await dbContext.Absences.AddAsync(new Domain.Absence
             {
-                Reason = request.Reason,
-                Type = request.Type,
-                From = request.From,
-                Until = request.Until,
-                UserId = request.UserId
+                Reason = command.Reason,
+                Type = command.Type,
+                From = command.From,
+                Until = command.Until,
+                UserId = command.UserId
             }, cancellationToken);
 
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Absence/RemoveAbsenceCommand.cs
+++ b/src/Schuly.Application/Commands/Absence/RemoveAbsenceCommand.cs
@@ -1,35 +1,26 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Absence
 {
-    public class RemoveAbsenceCommand : IRequest
+    public record RemoveAbsenceCommand(long AbsenceId) : ICommand<Result>;
+
+    public class RemoveAbsenceCommandHandler(SchulyDbContext dbContext) : ICommandHandler<RemoveAbsenceCommand, Result>
     {
-        public required long AbsenceId { get; set; }
-    }
-
-    public class RemoveAbsenceCommandHandler : IRequestHandler<RemoveAbsenceCommand>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public RemoveAbsenceCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(RemoveAbsenceCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var absence = await dbContext.Absences
+                .SingleOrDefaultAsync(a => a.Id == command.AbsenceId, cancellationToken);
 
-        public async ValueTask<Unit> Handle(RemoveAbsenceCommand request, CancellationToken cancellationToken)
-        {
-            var absence = await _dbContext.Absences
-                .SingleOrDefaultAsync(a => a.Id == request.AbsenceId, cancellationToken);
+            if (absence == null)
+                return Result.Failure($"Absence with ID '{command.AbsenceId}' not found");
 
-            if (absence != null)
-            {
-                _dbContext.Absences.Remove(absence);
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
+            dbContext.Absences.Remove(absence);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Absence/UpdateAbsenceCommand.cs
+++ b/src/Schuly.Application/Commands/Absence/UpdateAbsenceCommand.cs
@@ -1,46 +1,32 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Absence
 {
-    public class UpdateAbsenceCommand : IRequest
+    public record UpdateAbsenceCommand(long AbsenceId, string Reason, AbsenceType Type, DateTime From, DateTime Until, Guid UserId) : ICommand<Result>;
+
+    public class UpdateAbsenceCommandHandler(SchulyDbContext dbContext) : ICommandHandler<UpdateAbsenceCommand, Result>
     {
-        public required long AbsenceId { get; set; }
-        public required string Reason { get; set; }
-        public required AbsenceType Type { get; set; }
-        public required DateTime From { get; set; }
-        public required DateTime Until { get; set; }
-        public required Guid UserId { get; set; }
-    }
-
-    public class UpdateAbsenceCommandHandler : IRequestHandler<UpdateAbsenceCommand>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public UpdateAbsenceCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(UpdateAbsenceCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var absence = await dbContext.Absences
+                .SingleOrDefaultAsync(a => a.Id == command.AbsenceId, cancellationToken);
 
-        public async ValueTask<Unit> Handle(UpdateAbsenceCommand request, CancellationToken cancellationToken)
-        {
-            var absence = await _dbContext.Absences
-                .SingleOrDefaultAsync(a => a.Id == request.AbsenceId, cancellationToken);
+            if (absence == null)
+                return Result.Failure($"Absence with ID '{command.AbsenceId}' not found");
 
-            if (absence != null)
-            {
-                absence.Reason = request.Reason;
-                absence.Type = request.Type;
-                absence.From = request.From;
-                absence.Until = request.Until;
-                absence.UserId = request.UserId;
+            absence.Reason = command.Reason;
+            absence.Type = command.Type;
+            absence.From = command.From;
+            absence.Until = command.Until;
+            absence.UserId = command.UserId;
 
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Agenda/CreateAgendaEntryCommand.cs
+++ b/src/Schuly.Application/Commands/Agenda/CreateAgendaEntryCommand.cs
@@ -1,44 +1,30 @@
 using Mediator;
+using Schuly.Application.Models;
 using Schuly.Domain;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Agenda
 {
-    public class CreateAgendaEntryCommand : IRequest
+    public record CreateAgendaEntryCommand(AgendaEntryType EntryType, string Title, string? Description, string? Place, DateTime Date, Guid ClassId) : ICommand<Result>;
+
+    public class CreateAgendaEntryCommandHandler(SchulyDbContext dbContext) : ICommandHandler<CreateAgendaEntryCommand, Result>
     {
-        public required AgendaEntryType EntryType { get; set; }
-        public required string Title { get; set; }
-        public string? Description { get; set; }
-        public string? Place { get; set; }
-        public required DateTime Date { get; set; }
-        public required Guid ClassId { get; set; }
-    }
-
-    public class CreateAgendaEntryCommandHandler : IRequestHandler<CreateAgendaEntryCommand>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public CreateAgendaEntryCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(CreateAgendaEntryCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<Unit> Handle(CreateAgendaEntryCommand request, CancellationToken cancellationToken)
-        {
-            await _dbContext.AgendaEntries.AddAsync(new AgendaEntry
+            await dbContext.AgendaEntries.AddAsync(new AgendaEntry
             {
-                EntryType = request.EntryType,
-                Title = request.Title,
-                Description = request.Description,
-                Place = request.Place,
-                Date = request.Date,
-                ClassId = request.ClassId
+                EntryType = command.EntryType,
+                Title = command.Title,
+                Description = command.Description,
+                Place = command.Place,
+                Date = command.Date,
+                ClassId = command.ClassId
             }, cancellationToken);
 
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Agenda/DeleteAgendaEntryCommand.cs
+++ b/src/Schuly.Application/Commands/Agenda/DeleteAgendaEntryCommand.cs
@@ -1,35 +1,26 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Agenda
 {
-    public class DeleteAgendaEntryCommand : IRequest
+    public record DeleteAgendaEntryCommand(long AgendaEntryId) : ICommand<Result>;
+
+    public class DeleteAgendaEntryCommandHandler(SchulyDbContext dbContext) : ICommandHandler<DeleteAgendaEntryCommand, Result>
     {
-        public required long AgendaEntryId { get; set; }
-    }
-
-    public class DeleteAgendaEntryCommandHandler : IRequestHandler<DeleteAgendaEntryCommand>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public DeleteAgendaEntryCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(DeleteAgendaEntryCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var agendaEntry = await dbContext.AgendaEntries
+                .SingleOrDefaultAsync(a => a.Id == command.AgendaEntryId, cancellationToken);
 
-        public async ValueTask<Unit> Handle(DeleteAgendaEntryCommand request, CancellationToken cancellationToken)
-        {
-            var agendaEntry = await _dbContext.AgendaEntries
-                .SingleOrDefaultAsync(a => a.Id == request.AgendaEntryId, cancellationToken);
+            if (agendaEntry == null)
+                return Result.Failure($"Agenda entry with ID '{command.AgendaEntryId}' not found");
 
-            if (agendaEntry != null)
-            {
-                _dbContext.AgendaEntries.Remove(agendaEntry);
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
+            dbContext.AgendaEntries.Remove(agendaEntry);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Agenda/UpdateAgendaEntryCommand.cs
+++ b/src/Schuly.Application/Commands/Agenda/UpdateAgendaEntryCommand.cs
@@ -1,48 +1,33 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Agenda
 {
-    public class UpdateAgendaEntryCommand : IRequest
+    public record UpdateAgendaEntryCommand(long AgendaEntryId, AgendaEntryType EntryType, string Title, string? Description, string? Place, DateTime Date, Guid ClassId) : ICommand<Result>;
+
+    public class UpdateAgendaEntryCommandHandler(SchulyDbContext dbContext) : ICommandHandler<UpdateAgendaEntryCommand, Result>
     {
-        public required long AgendaEntryId { get; set; }
-        public required AgendaEntryType EntryType { get; set; }
-        public required string Title { get; set; }
-        public string? Description { get; set; }
-        public string? Place { get; set; }
-        public required DateTime Date { get; set; }
-        public required Guid ClassId { get; set; }
-    }
-
-    public class UpdateAgendaEntryCommandHandler : IRequestHandler<UpdateAgendaEntryCommand>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public UpdateAgendaEntryCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(UpdateAgendaEntryCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var agendaEntry = await dbContext.AgendaEntries
+                .SingleOrDefaultAsync(a => a.Id == command.AgendaEntryId, cancellationToken);
 
-        public async ValueTask<Unit> Handle(UpdateAgendaEntryCommand request, CancellationToken cancellationToken)
-        {
-            var agendaEntry = await _dbContext.AgendaEntries
-                .SingleOrDefaultAsync(a => a.Id == request.AgendaEntryId, cancellationToken);
+            if (agendaEntry == null)
+                return Result.Failure($"Agenda entry with ID '{command.AgendaEntryId}' not found");
 
-            if (agendaEntry != null)
-            {
-                agendaEntry.EntryType = request.EntryType;
-                agendaEntry.Title = request.Title;
-                agendaEntry.Description = request.Description;
-                agendaEntry.Place = request.Place;
-                agendaEntry.Date = request.Date;
-                agendaEntry.ClassId = request.ClassId;
+            agendaEntry.EntryType = command.EntryType;
+            agendaEntry.Title = command.Title;
+            agendaEntry.Description = command.Description;
+            agendaEntry.Place = command.Place;
+            agendaEntry.Date = command.Date;
+            agendaEntry.ClassId = command.ClassId;
 
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/ApplicationUser/CreateApplicationUserCommand.cs
+++ b/src/Schuly.Application/Commands/ApplicationUser/CreateApplicationUserCommand.cs
@@ -1,58 +1,40 @@
 using Mediator;
 using Schuly.Application.Authorization;
+using Schuly.Application.Models;
 using Schuly.Application.Services;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.ApplicationUser
 {
-    public class CreateApplicationUserCommand : IRequest<Guid>, IHasAuthorization
+    public record CreateApplicationUserCommand(string AuthenticationEmail, string Password, string? DisplayName) : ICommand<Result<Guid>>, IHasAuthorization
     {
-        public required string AuthenticationEmail { get; set; }
-        public required string Password { get; set; }
-        public string? DisplayName { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class CreateApplicationUserCommandHandler : IRequestHandler<CreateApplicationUserCommand, Guid>
+    public class CreateApplicationUserCommandHandler(
+        SchulyDbContext dbContext,
+        IPasswordHashingService passwordHashingService) : ICommandHandler<CreateApplicationUserCommand, Result<Guid>>
     {
-        private readonly SchulyDbContext _dbContext;
-        private readonly IPasswordHashingService _passwordHashingService;
-
-        public CreateApplicationUserCommandHandler(
-            SchulyDbContext dbContext,
-            IPasswordHashingService passwordHashingService)
+        public async ValueTask<Result<Guid>> Handle(CreateApplicationUserCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-            _passwordHashingService = passwordHashingService;
-        }
+            var (passwordHash, passwordSalt) = passwordHashingService.HashPassword(command.Password);
 
-        public async ValueTask<Guid> Handle(CreateApplicationUserCommand request, CancellationToken cancellationToken)
-        {
-            // Hash the password
-            var (passwordHash, passwordSalt) = _passwordHashingService.HashPassword(request.Password);
-
-            // Create the new ApplicationUser
             var applicationUser = new Domain.ApplicationUser
             {
                 Id = Guid.NewGuid(),
-                AuthenticationEmail = request.AuthenticationEmail,
-                DisplayName = request.DisplayName,
+                AuthenticationEmail = command.AuthenticationEmail,
+                DisplayName = command.DisplayName,
                 PasswordHash = passwordHash,
                 PasswordSalt = passwordSalt,
                 IsEmailVerified = false,
                 IsTwoFactorEnabled = false
             };
 
-            // Add to database
-            await _dbContext.ApplicationUsers.AddAsync(applicationUser, cancellationToken);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await dbContext.ApplicationUsers.AddAsync(applicationUser, cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return applicationUser.Id;
+            return Result<Guid>.Success(applicationUser.Id);
         }
     }
 }

--- a/src/Schuly.Application/Commands/ApplicationUser/DeleteApplicationUserCommand.cs
+++ b/src/Schuly.Application/Commands/ApplicationUser/DeleteApplicationUserCommand.cs
@@ -1,51 +1,37 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.ApplicationUser
 {
-    public class DeleteApplicationUserCommand : IRequest, IHasAuthorization
+    public record DeleteApplicationUserCommand(Guid ApplicationUserId) : ICommand<Result>, IHasAuthorization
     {
-        public required Guid ApplicationUserId { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class DeleteApplicationUserCommandHandler : IRequestHandler<DeleteApplicationUserCommand>
+    public class DeleteApplicationUserCommandHandler(SchulyDbContext dbContext) : ICommandHandler<DeleteApplicationUserCommand, Result>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public DeleteApplicationUserCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(DeleteApplicationUserCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<Unit> Handle(DeleteApplicationUserCommand request, CancellationToken cancellationToken)
-        {
-            // Retrieve the ApplicationUser with its SchoolUsers
-            var applicationUser = await _dbContext.ApplicationUsers
+            var applicationUser = await dbContext.ApplicationUsers
                 .Include(au => au.SchoolUsers)
-                .FirstOrDefaultAsync(au => au.Id == request.ApplicationUserId, cancellationToken);
+                .FirstOrDefaultAsync(au => au.Id == command.ApplicationUserId, cancellationToken);
 
             if (applicationUser == null)
-                throw new InvalidOperationException($"ApplicationUser with ID '{request.ApplicationUserId}' not found.");
+                return Result.Failure($"ApplicationUser with ID '{command.ApplicationUserId}' not found");
 
-            // Prevent deletion if SchoolUsers are linked
             if (applicationUser.SchoolUsers.Count > 0)
-                throw new InvalidOperationException(
+                return Result.Failure(
                     $"Cannot delete ApplicationUser with {applicationUser.SchoolUsers.Count} linked SchoolUser(s). " +
                     "Delete all linked SchoolUsers first.");
 
-            // Delete the ApplicationUser
-            _dbContext.ApplicationUsers.Remove(applicationUser);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            dbContext.ApplicationUsers.Remove(applicationUser);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/ApplicationUser/UpdateApplicationUserCommand.cs
+++ b/src/Schuly.Application/Commands/ApplicationUser/UpdateApplicationUserCommand.cs
@@ -1,52 +1,36 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.ApplicationUser
 {
-    public class UpdateApplicationUserCommand : IRequest, IHasAuthorization
+    public record UpdateApplicationUserCommand(Guid ApplicationUserId, string? DisplayName, string? ProfilePictureUrl) : ICommand<Result>, IHasAuthorization
     {
-        public required Guid ApplicationUserId { get; set; }
-        public string? DisplayName { get; set; }
-        public string? ProfilePictureUrl { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class UpdateApplicationUserCommandHandler : IRequestHandler<UpdateApplicationUserCommand>
+    public class UpdateApplicationUserCommandHandler(SchulyDbContext dbContext) : ICommandHandler<UpdateApplicationUserCommand, Result>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public UpdateApplicationUserCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(UpdateApplicationUserCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<Unit> Handle(UpdateApplicationUserCommand request, CancellationToken cancellationToken)
-        {
-            // Retrieve the ApplicationUser
-            var applicationUser = await _dbContext.ApplicationUsers
-                .FirstOrDefaultAsync(au => au.Id == request.ApplicationUserId, cancellationToken);
+            var applicationUser = await dbContext.ApplicationUsers
+                .FirstOrDefaultAsync(au => au.Id == command.ApplicationUserId, cancellationToken);
 
             if (applicationUser == null)
-                throw new InvalidOperationException($"ApplicationUser with ID '{request.ApplicationUserId}' not found.");
+                return Result.Failure($"ApplicationUser with ID '{command.ApplicationUserId}' not found");
 
-            // Update properties
-            if (!string.IsNullOrEmpty(request.DisplayName))
-                applicationUser.DisplayName = request.DisplayName;
+            if (!string.IsNullOrEmpty(command.DisplayName))
+                applicationUser.DisplayName = command.DisplayName;
 
-            if (!string.IsNullOrEmpty(request.ProfilePictureUrl))
-                applicationUser.ProfilePictureUrl = request.ProfilePictureUrl;
+            if (!string.IsNullOrEmpty(command.ProfilePictureUrl))
+                applicationUser.ProfilePictureUrl = command.ProfilePictureUrl;
 
-            // Save changes
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Class/CreateClassCommand.cs
+++ b/src/Schuly.Application/Commands/Class/CreateClassCommand.cs
@@ -1,41 +1,29 @@
 using Mediator;
 using Schuly.Application.Authorization;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Class
 {
-    public class CreateClassCommand : IRequest, IHasAuthorization
+    public record CreateClassCommand(string Name, string? Description) : ICommand<Result>, IHasAuthorization
     {
-        public required string Name { get; set; }
-        public string? Description { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Teacher;
-        }
+        public Roles GetRequiredRole() => Roles.Teacher;
     }
 
-    public class CreateClassCommandHandler : IRequestHandler<CreateClassCommand>
+    public class CreateClassCommandHandler(SchulyDbContext dbContext) : ICommandHandler<CreateClassCommand, Result>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public CreateClassCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(CreateClassCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<Unit> Handle(CreateClassCommand request, CancellationToken cancellationToken)
-        {
-            await _dbContext.Classes.AddAsync(new Domain.Class
+            await dbContext.Classes.AddAsync(new Domain.Class
             {
-                Name = request.Name,
-                Description = request.Description
+                Name = command.Name,
+                Description = command.Description
             }, cancellationToken);
 
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Class/DeleteClassCommand.cs
+++ b/src/Schuly.Application/Commands/Class/DeleteClassCommand.cs
@@ -1,35 +1,26 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Class
 {
-    public class DeleteClassCommand : IRequest
+    public record DeleteClassCommand(Guid ClassId) : ICommand<Result>;
+
+    public class DeleteClassCommandHandler(SchulyDbContext dbContext) : ICommandHandler<DeleteClassCommand, Result>
     {
-        public required Guid ClassId { get; set; }
-    }
-
-    public class DeleteClassCommandHandler : IRequestHandler<DeleteClassCommand>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public DeleteClassCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(DeleteClassCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var classEntity = await dbContext.Classes
+                .SingleOrDefaultAsync(c => c.Id == command.ClassId, cancellationToken);
 
-        public async ValueTask<Unit> Handle(DeleteClassCommand request, CancellationToken cancellationToken)
-        {
-            var classEntity = await _dbContext.Classes
-                .SingleOrDefaultAsync(c => c.Id == request.ClassId, cancellationToken);
+            if (classEntity == null)
+                return Result.Failure($"Class with ID '{command.ClassId}' not found");
 
-            if (classEntity != null)
-            {
-                _dbContext.Classes.Remove(classEntity);
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
+            dbContext.Classes.Remove(classEntity);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Class/EnrolStudentCommand.cs
+++ b/src/Schuly.Application/Commands/Class/EnrolStudentCommand.cs
@@ -1,32 +1,28 @@
-﻿using Mediator;
+using Mediator;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
+
 namespace Schuly.Application.Commands.Class
 {
-    public class EnrolStudentCommand : IRequest
-    {
-        public required Guid UserId {  get; set; }
-        public required Guid ClassId {  get; set; }
-    }
+    public record EnrolStudentCommand(Guid UserId, Guid ClassId) : ICommand<Result>;
 
-    public class EnrolStudentCommandHandler : IRequestHandler<EnrolStudentCommand>
+    public class EnrolStudentCommandHandler(SchulyDbContext dbContext) : ICommandHandler<EnrolStudentCommand, Result>
     {
-        private readonly SchulyDbContext _dbContext;
+        public async ValueTask<Result> Handle(EnrolStudentCommand command, CancellationToken cancellationToken)
+        {
+            var user = await dbContext.Users.SingleOrDefaultAsync(u => u.Id == command.UserId, cancellationToken);
+            if (user == null)
+                return Result.Failure($"User with ID '{command.UserId}' not found");
 
-        public EnrolStudentCommandHandler(SchulyDbContext dbContext)
-        {
-            _dbContext = dbContext;
-        }
-        public async ValueTask<Unit> Handle(EnrolStudentCommand request, CancellationToken cancellationToken)
-        {
-            var user = await _dbContext.Users.SingleAsync(u => u.Id == request.UserId, cancellationToken);
-            var @class = await _dbContext.Classes.AsTracking().SingleAsync(c => c.Id == request.ClassId, cancellationToken);
+            var @class = await dbContext.Classes.AsTracking().SingleOrDefaultAsync(c => c.Id == command.ClassId, cancellationToken);
+            if (@class == null)
+                return Result.Failure($"Class with ID '{command.ClassId}' not found");
 
             @class.Students.Add(user);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            await _dbContext.SaveChangesAsync(cancellationToken);
-
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Class/UpdateClassCommand.cs
+++ b/src/Schuly.Application/Commands/Class/UpdateClassCommand.cs
@@ -1,39 +1,28 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Class
 {
-    public class UpdateClassCommand : IRequest
+    public record UpdateClassCommand(Guid ClassId, string Name, string? Description) : ICommand<Result>;
+
+    public class UpdateClassCommandHandler(SchulyDbContext dbContext) : ICommandHandler<UpdateClassCommand, Result>
     {
-        public required Guid ClassId { get; set; }
-        public required string Name { get; set; }
-        public string? Description { get; set; }
-    }
-
-    public class UpdateClassCommandHandler : IRequestHandler<UpdateClassCommand>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public UpdateClassCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(UpdateClassCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var classEntity = await dbContext.Classes
+                .SingleOrDefaultAsync(c => c.Id == command.ClassId, cancellationToken);
 
-        public async ValueTask<Unit> Handle(UpdateClassCommand request, CancellationToken cancellationToken)
-        {
-            var classEntity = await _dbContext.Classes
-                .SingleOrDefaultAsync(c => c.Id == request.ClassId, cancellationToken);
+            if (classEntity == null)
+                return Result.Failure($"Class with ID '{command.ClassId}' not found");
 
-            if (classEntity != null)
-            {
-                classEntity.Name = request.Name;
-                classEntity.Description = request.Description;
+            classEntity.Name = command.Name;
+            classEntity.Description = command.Description;
 
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Exam/AddGradeToExamCommand.cs
+++ b/src/Schuly.Application/Commands/Exam/AddGradeToExamCommand.cs
@@ -1,41 +1,33 @@
-﻿using Mediator;
+using Mediator;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Exam
 {
-    public class AddGradeToExamCommand : IRequest
+    public record AddGradeToExamCommand(long ExamId, Guid StudentId, decimal Grade, decimal Weight = 1) : ICommand<Result>;
+
+    public class AddGradeToExamCommandHandler(SchulyDbContext dbContext) : ICommandHandler<AddGradeToExamCommand, Result>
     {
-        public required long ExamId { get; set; }
-        public required Guid StudentId { get; set; }
-        public required decimal Grade { get; set; }
-        public decimal Weight { get; set; } = 1;
-    }
-
-    public class AddGradeToExamControllerHandler : IRequestHandler<AddGradeToExamCommand>
-    {
-        private readonly SchulyDbContext _dbContext;
-        public AddGradeToExamControllerHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(AddGradeToExamCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var exam = await dbContext.Exams.AsTracking()
+                .SingleOrDefaultAsync(e => e.Id == command.ExamId, cancellationToken);
 
-        public async ValueTask<Unit> Handle(AddGradeToExamCommand request, CancellationToken cancellationToken)
-        {
-            var exam = await _dbContext.Exams.AsTracking().SingleAsync(e => e.Id == request.ExamId, cancellationToken);
+            if (exam == null)
+                return Result.Failure($"Exam with ID '{command.ExamId}' not found");
 
-            exam.Grades.Add(new Domain.Grade()
+            exam.Grades.Add(new Domain.Grade
             {
-                ExamId = request.ExamId,
-                UserId = request.StudentId,
-
-                Score = request.Grade,
-                Weighting = request.Weight,
+                ExamId = command.ExamId,
+                UserId = command.StudentId,
+                Score = command.Grade,
+                Weighting = command.Weight,
             });
 
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Exam/CreateExamCommand.cs
+++ b/src/Schuly.Application/Commands/Exam/CreateExamCommand.cs
@@ -1,46 +1,31 @@
 using Mediator;
 using Schuly.Application.Authorization;
-using Schuly.Domain;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Exam
 {
-    public class CreateExamCommand : IRequest, IHasAuthorization
+    public record CreateExamCommand(string Name, string? Description, ExamType Type, Guid ClassId) : ICommand<Result>, IHasAuthorization
     {
-        public required string Name { get; set; }
-        public string? Description { get; set; }
-        public ExamType Type { get; set; }
-        public required Guid ClassId { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Teacher;
-        }
+        public Roles GetRequiredRole() => Roles.Teacher;
     }
 
-    public class CreateExamCommandHandler : IRequestHandler<CreateExamCommand>
+    public class CreateExamCommandHandler(SchulyDbContext dbContext) : ICommandHandler<CreateExamCommand, Result>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public CreateExamCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(CreateExamCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<Unit> Handle(CreateExamCommand request, CancellationToken cancellationToken)
-        {
-            await _dbContext.Exams.AddAsync(new Domain.Exam
+            await dbContext.Exams.AddAsync(new Domain.Exam
             {
-                Name = request.Name,
-                Description = request.Description,
-                Type = request.Type,
-                ClassId = request.ClassId
+                Name = command.Name,
+                Description = command.Description,
+                Type = command.Type,
+                ClassId = command.ClassId
             }, cancellationToken);
 
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Exam/DeleteExamCommand.cs
+++ b/src/Schuly.Application/Commands/Exam/DeleteExamCommand.cs
@@ -1,35 +1,26 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Exam
 {
-    public class DeleteExamCommand : IRequest
+    public record DeleteExamCommand(long ExamId) : ICommand<Result>;
+
+    public class DeleteExamCommandHandler(SchulyDbContext dbContext) : ICommandHandler<DeleteExamCommand, Result>
     {
-        public required long ExamId { get; set; }
-    }
-
-    public class DeleteExamCommandHandler : IRequestHandler<DeleteExamCommand>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public DeleteExamCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(DeleteExamCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var exam = await dbContext.Exams
+                .SingleOrDefaultAsync(e => e.Id == command.ExamId, cancellationToken);
 
-        public async ValueTask<Unit> Handle(DeleteExamCommand request, CancellationToken cancellationToken)
-        {
-            var exam = await _dbContext.Exams
-                .SingleOrDefaultAsync(e => e.Id == request.ExamId, cancellationToken);
+            if (exam == null)
+                return Result.Failure($"Exam with ID '{command.ExamId}' not found");
 
-            if (exam != null)
-            {
-                _dbContext.Exams.Remove(exam);
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
+            dbContext.Exams.Remove(exam);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/Exam/UpdateExamCommand.cs
+++ b/src/Schuly.Application/Commands/Exam/UpdateExamCommand.cs
@@ -1,44 +1,31 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.Exam
 {
-    public class UpdateExamCommand : IRequest
+    public record UpdateExamCommand(long ExamId, string Name, string? Description, ExamType Type, Guid ClassId) : ICommand<Result>;
+
+    public class UpdateExamCommandHandler(SchulyDbContext dbContext) : ICommandHandler<UpdateExamCommand, Result>
     {
-        public required long ExamId { get; set; }
-        public required string Name { get; set; }
-        public string? Description { get; set; }
-        public ExamType Type { get; set; }
-        public required Guid ClassId { get; set; }
-    }
-
-    public class UpdateExamCommandHandler : IRequestHandler<UpdateExamCommand>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public UpdateExamCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(UpdateExamCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var exam = await dbContext.Exams
+                .SingleOrDefaultAsync(e => e.Id == command.ExamId, cancellationToken);
 
-        public async ValueTask<Unit> Handle(UpdateExamCommand request, CancellationToken cancellationToken)
-        {
-            var exam = await _dbContext.Exams
-                .SingleOrDefaultAsync(e => e.Id == request.ExamId, cancellationToken);
+            if (exam == null)
+                return Result.Failure($"Exam with ID '{command.ExamId}' not found");
 
-            if (exam != null)
-            {
-                exam.Name = request.Name;
-                exam.Description = request.Description;
-                exam.Type = request.Type;
-                exam.ClassId = request.ClassId;
+            exam.Name = command.Name;
+            exam.Description = command.Description;
+            exam.Type = command.Type;
+            exam.ClassId = command.ClassId;
 
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/School/CreateSchoolCommand.cs
+++ b/src/Schuly.Application/Commands/School/CreateSchoolCommand.cs
@@ -1,59 +1,48 @@
 using Mediator;
 using Schuly.Application.Authorization;
-using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.School
 {
-    public class CreateSchoolCommand : IRequest<long>, IHasAuthorization
+    public record CreateSchoolCommand(
+        string Name,
+        string? Description,
+        string? Email,
+        string? PhoneNumber,
+        string? Website,
+        string? Street,
+        string? City,
+        string? State,
+        string? Zip,
+        string? Country) : ICommand<Result<long>>, IHasAuthorization
     {
-        public required string Name { get; set; }
-        public string? Description { get; set; }
-        public string? Email { get; set; }
-        public string? PhoneNumber { get; set; }
-        public string? Website { get; set; }
-        public string? Street { get; set; }
-        public string? City { get; set; }
-        public string? State { get; set; }
-        public string? Zip { get; set; }
-        public string? Country { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class CreateSchoolCommandHandler : IRequestHandler<CreateSchoolCommand, long>
+    public class CreateSchoolCommandHandler(SchulyDbContext dbContext) : ICommandHandler<CreateSchoolCommand, Result<long>>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public CreateSchoolCommandHandler(SchulyDbContext dbContext)
-        {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<long> Handle(CreateSchoolCommand request, CancellationToken cancellationToken)
+        public async ValueTask<Result<long>> Handle(CreateSchoolCommand command, CancellationToken cancellationToken)
         {
             var school = new Domain.School
             {
-                Name = request.Name,
-                Description = request.Description,
-                Email = request.Email,
-                PhoneNumber = request.PhoneNumber,
-                Website = request.Website,
-                Street = request.Street,
-                City = request.City,
-                State = request.State,
-                Zip = request.Zip,
-                Country = request.Country
+                Name = command.Name,
+                Description = command.Description,
+                Email = command.Email,
+                PhoneNumber = command.PhoneNumber,
+                Website = command.Website,
+                Street = command.Street,
+                City = command.City,
+                State = command.State,
+                Zip = command.Zip,
+                Country = command.Country
             };
 
-            await _dbContext.Schools.AddAsync(school, cancellationToken);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await dbContext.Schools.AddAsync(school, cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return school.Id;
+            return Result<long>.Success(school.Id);
         }
     }
 }

--- a/src/Schuly.Application/Commands/School/DeleteSchoolCommand.cs
+++ b/src/Schuly.Application/Commands/School/DeleteSchoolCommand.cs
@@ -1,48 +1,37 @@
 using Mediator;
+using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
-using Microsoft.EntityFrameworkCore;
 
 namespace Schuly.Application.Commands.School
 {
-    public class DeleteSchoolCommand : IRequest, IHasAuthorization
+    public record DeleteSchoolCommand(long Id) : ICommand<Result>, IHasAuthorization
     {
-        public required long Id { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class DeleteSchoolCommandHandler : IRequestHandler<DeleteSchoolCommand>
+    public class DeleteSchoolCommandHandler(SchulyDbContext dbContext) : ICommandHandler<DeleteSchoolCommand, Result>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public DeleteSchoolCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(DeleteSchoolCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<Unit> Handle(DeleteSchoolCommand request, CancellationToken cancellationToken)
-        {
-            var school = await _dbContext.Schools
+            var school = await dbContext.Schools
                 .Include(s => s.SchoolUsers)
                 .Include(s => s.Classes)
                 .Include(s => s.Users)
-                .FirstOrDefaultAsync(s => s.Id == request.Id, cancellationToken: cancellationToken);
+                .FirstOrDefaultAsync(s => s.Id == command.Id, cancellationToken: cancellationToken);
 
             if (school == null)
-                throw new InvalidOperationException($"School with ID {request.Id} not found");
+                return Result.Failure($"School with ID {command.Id} not found");
 
-            if (school.SchoolUsers.Any() || school.Classes.Any() || school.Users.Any(u => u.SchoolId == request.Id))
-                throw new InvalidOperationException("Cannot delete school that has associated users or classes");
+            if (school.SchoolUsers.Any() || school.Classes.Any() || school.Users.Any(u => u.SchoolId == command.Id))
+                return Result.Failure("Cannot delete school that has associated users or classes");
 
-            _dbContext.Schools.Remove(school);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            dbContext.Schools.Remove(school);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/School/UpdateSchoolCommand.cs
+++ b/src/Schuly.Application/Commands/School/UpdateSchoolCommand.cs
@@ -1,60 +1,50 @@
 using Mediator;
 using Schuly.Application.Authorization;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.School
 {
-    public class UpdateSchoolCommand : IRequest, IHasAuthorization
+    public record UpdateSchoolCommand(
+        long Id,
+        string Name,
+        string? Description,
+        string? Email,
+        string? PhoneNumber,
+        string? Website,
+        string? Street,
+        string? City,
+        string? State,
+        string? Zip,
+        string? Country) : ICommand<Result>, IHasAuthorization
     {
-        public required long Id { get; set; }
-        public required string Name { get; set; }
-        public string? Description { get; set; }
-        public string? Email { get; set; }
-        public string? PhoneNumber { get; set; }
-        public string? Website { get; set; }
-        public string? Street { get; set; }
-        public string? City { get; set; }
-        public string? State { get; set; }
-        public string? Zip { get; set; }
-        public string? Country { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class UpdateSchoolCommandHandler : IRequestHandler<UpdateSchoolCommand>
+    public class UpdateSchoolCommandHandler(SchulyDbContext dbContext) : ICommandHandler<UpdateSchoolCommand, Result>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public UpdateSchoolCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(UpdateSchoolCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var school = await dbContext.Schools.FindAsync([command.Id], cancellationToken: cancellationToken);
 
-        public async ValueTask<Unit> Handle(UpdateSchoolCommand request, CancellationToken cancellationToken)
-        {
-            var school = await _dbContext.Schools.FindAsync(new object[] { request.Id }, cancellationToken: cancellationToken);
             if (school == null)
-                throw new InvalidOperationException($"School with ID {request.Id} not found");
+                return Result.Failure($"School with ID {command.Id} not found");
 
-            school.Name = request.Name;
-            school.Description = request.Description;
-            school.Email = request.Email;
-            school.PhoneNumber = request.PhoneNumber;
-            school.Website = request.Website;
-            school.Street = request.Street;
-            school.City = request.City;
-            school.State = request.State;
-            school.Zip = request.Zip;
-            school.Country = request.Country;
+            school.Name = command.Name;
+            school.Description = command.Description;
+            school.Email = command.Email;
+            school.PhoneNumber = command.PhoneNumber;
+            school.Website = command.Website;
+            school.Street = command.Street;
+            school.City = command.City;
+            school.State = command.State;
+            school.Zip = command.Zip;
+            school.Country = command.Country;
 
-            _dbContext.Schools.Update(school);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/SchoolUser/CreateSchoolUserCommand.cs
+++ b/src/Schuly.Application/Commands/SchoolUser/CreateSchoolUserCommand.cs
@@ -1,67 +1,57 @@
 using Mediator;
 using Schuly.Application.Authorization;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.SchoolUser
 {
-    public class CreateSchoolUserCommand : IRequest<long>, IHasAuthorization
+    public record CreateSchoolUserCommand(
+        Guid ApplicationUserId,
+        string FirstName,
+        string LastName,
+        string Email,
+        string? PrivateEmail,
+        string? PhoneNumber,
+        string? Street,
+        string? City,
+        string? Zip,
+        DateOnly Birthday,
+        DateOnly EntryDate,
+        Roles Role,
+        string? StudentNumber,
+        string? TeacherCode) : ICommand<Result<long>>, IHasAuthorization
     {
-        public required Guid ApplicationUserId { get; set; }
-        public required string FirstName { get; set; }
-        public required string LastName { get; set; }
-        public required string Email { get; set; }
-        public string? PrivateEmail { get; set; }
-        public string? PhoneNumber { get; set; }
-        public string? Street { get; set; }
-        public string? City { get; set; }
-        public string? Zip { get; set; }
-        public required DateOnly Birthday { get; set; }
-        public required DateOnly EntryDate { get; set; }
-        public required Roles Role { get; set; }
-        public string? StudentNumber { get; set; }
-        public string? TeacherCode { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class CreateSchoolUserCommandHandler : IRequestHandler<CreateSchoolUserCommand, long>
+    public class CreateSchoolUserCommandHandler(SchulyDbContext dbContext) : ICommandHandler<CreateSchoolUserCommand, Result<long>>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public CreateSchoolUserCommandHandler(SchulyDbContext dbContext)
-        {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<long> Handle(CreateSchoolUserCommand request, CancellationToken cancellationToken)
+        public async ValueTask<Result<long>> Handle(CreateSchoolUserCommand command, CancellationToken cancellationToken)
         {
             var schoolUser = new Domain.SchoolUser
             {
-                ApplicationUserId = request.ApplicationUserId,
-                FirstName = request.FirstName,
-                LastName = request.LastName,
-                Email = request.Email,
-                PrivateEmail = request.PrivateEmail,
-                PhoneNumber = request.PhoneNumber,
-                Street = request.Street,
-                City = request.City,
-                Zip = request.Zip,
-                Birthday = request.Birthday,
-                EntryDate = request.EntryDate,
-                Role = request.Role,
+                ApplicationUserId = command.ApplicationUserId,
+                FirstName = command.FirstName,
+                LastName = command.LastName,
+                Email = command.Email,
+                PrivateEmail = command.PrivateEmail,
+                PhoneNumber = command.PhoneNumber,
+                Street = command.Street,
+                City = command.City,
+                Zip = command.Zip,
+                Birthday = command.Birthday,
+                EntryDate = command.EntryDate,
+                Role = command.Role,
                 State = UserState.Active,
-                StudentNumber = request.StudentNumber,
-                TeacherCode = request.TeacherCode
+                StudentNumber = command.StudentNumber,
+                TeacherCode = command.TeacherCode
             };
 
-            await _dbContext.SchoolUsers.AddAsync(schoolUser, cancellationToken);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await dbContext.SchoolUsers.AddAsync(schoolUser, cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return schoolUser.Id;
+            return Result<long>.Success(schoolUser.Id);
         }
     }
 }

--- a/src/Schuly.Application/Commands/SchoolUser/DeleteSchoolUserCommand.cs
+++ b/src/Schuly.Application/Commands/SchoolUser/DeleteSchoolUserCommand.cs
@@ -1,42 +1,31 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.SchoolUser
 {
-    public class DeleteSchoolUserCommand : IRequest, IHasAuthorization
+    public record DeleteSchoolUserCommand(long SchoolUserId) : ICommand<Result>, IHasAuthorization
     {
-        public required long SchoolUserId { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class DeleteSchoolUserCommandHandler : IRequestHandler<DeleteSchoolUserCommand>
+    public class DeleteSchoolUserCommandHandler(SchulyDbContext dbContext) : ICommandHandler<DeleteSchoolUserCommand, Result>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public DeleteSchoolUserCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(DeleteSchoolUserCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<Unit> Handle(DeleteSchoolUserCommand request, CancellationToken cancellationToken)
-        {
-            var schoolUser = await _dbContext.SchoolUsers
-                .FirstOrDefaultAsync(su => su.Id == request.SchoolUserId, cancellationToken);
+            var schoolUser = await dbContext.SchoolUsers
+                .FirstOrDefaultAsync(su => su.Id == command.SchoolUserId, cancellationToken);
 
             if (schoolUser == null)
-                throw new InvalidOperationException($"SchoolUser with ID '{request.SchoolUserId}' not found.");
+                return Result.Failure($"SchoolUser with ID '{command.SchoolUserId}' not found");
 
-            _dbContext.SchoolUsers.Remove(schoolUser);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            dbContext.SchoolUsers.Remove(schoolUser);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/SchoolUser/UpdateSchoolUserCommand.cs
+++ b/src/Schuly.Application/Commands/SchoolUser/UpdateSchoolUserCommand.cs
@@ -1,81 +1,71 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.SchoolUser
 {
-    public class UpdateSchoolUserCommand : IRequest, IHasAuthorization
+    public record UpdateSchoolUserCommand(
+        long SchoolUserId,
+        string? FirstName,
+        string? LastName,
+        string? Email,
+        string? PrivateEmail,
+        string? PhoneNumber,
+        string? Street,
+        string? City,
+        string? Zip,
+        DateOnly? LeaveDate,
+        UserState? State) : ICommand<Result>, IHasAuthorization
     {
-        public required long SchoolUserId { get; set; }
-        public string? FirstName { get; set; }
-        public string? LastName { get; set; }
-        public string? Email { get; set; }
-        public string? PrivateEmail { get; set; }
-        public string? PhoneNumber { get; set; }
-        public string? Street { get; set; }
-        public string? City { get; set; }
-        public string? Zip { get; set; }
-        public DateOnly? LeaveDate { get; set; }
-        public UserState? State { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class UpdateSchoolUserCommandHandler : IRequestHandler<UpdateSchoolUserCommand>
+    public class UpdateSchoolUserCommandHandler(SchulyDbContext dbContext) : ICommandHandler<UpdateSchoolUserCommand, Result>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public UpdateSchoolUserCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(UpdateSchoolUserCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<Unit> Handle(UpdateSchoolUserCommand request, CancellationToken cancellationToken)
-        {
-            var schoolUser = await _dbContext.SchoolUsers
-                .FirstOrDefaultAsync(su => su.Id == request.SchoolUserId, cancellationToken);
+            var schoolUser = await dbContext.SchoolUsers
+                .FirstOrDefaultAsync(su => su.Id == command.SchoolUserId, cancellationToken);
 
             if (schoolUser == null)
-                throw new InvalidOperationException($"SchoolUser with ID '{request.SchoolUserId}' not found.");
+                return Result.Failure($"SchoolUser with ID '{command.SchoolUserId}' not found");
 
-            if (!string.IsNullOrEmpty(request.FirstName))
-                schoolUser.FirstName = request.FirstName;
+            if (!string.IsNullOrEmpty(command.FirstName))
+                schoolUser.FirstName = command.FirstName;
 
-            if (!string.IsNullOrEmpty(request.LastName))
-                schoolUser.LastName = request.LastName;
+            if (!string.IsNullOrEmpty(command.LastName))
+                schoolUser.LastName = command.LastName;
 
-            if (!string.IsNullOrEmpty(request.Email))
-                schoolUser.Email = request.Email;
+            if (!string.IsNullOrEmpty(command.Email))
+                schoolUser.Email = command.Email;
 
-            if (!string.IsNullOrEmpty(request.PrivateEmail))
-                schoolUser.PrivateEmail = request.PrivateEmail;
+            if (!string.IsNullOrEmpty(command.PrivateEmail))
+                schoolUser.PrivateEmail = command.PrivateEmail;
 
-            if (!string.IsNullOrEmpty(request.PhoneNumber))
-                schoolUser.PhoneNumber = request.PhoneNumber;
+            if (!string.IsNullOrEmpty(command.PhoneNumber))
+                schoolUser.PhoneNumber = command.PhoneNumber;
 
-            if (!string.IsNullOrEmpty(request.Street))
-                schoolUser.Street = request.Street;
+            if (!string.IsNullOrEmpty(command.Street))
+                schoolUser.Street = command.Street;
 
-            if (!string.IsNullOrEmpty(request.City))
-                schoolUser.City = request.City;
+            if (!string.IsNullOrEmpty(command.City))
+                schoolUser.City = command.City;
 
-            if (!string.IsNullOrEmpty(request.Zip))
-                schoolUser.Zip = request.Zip;
+            if (!string.IsNullOrEmpty(command.Zip))
+                schoolUser.Zip = command.Zip;
 
-            if (request.LeaveDate.HasValue)
-                schoolUser.LeaveDate = request.LeaveDate;
+            if (command.LeaveDate.HasValue)
+                schoolUser.LeaveDate = command.LeaveDate;
 
-            if (request.State.HasValue)
-                schoolUser.State = request.State.Value;
+            if (command.State.HasValue)
+                schoolUser.State = command.State.Value;
 
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/User/CreateUserCommand.cs
+++ b/src/Schuly.Application/Commands/User/CreateUserCommand.cs
@@ -1,59 +1,49 @@
 using Mediator;
 using Schuly.Application.Authorization;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.User
 {
-    public class CreateUserCommand : IRequest, IHasAuthorization
+    public record CreateUserCommand(
+        string FirstName,
+        string LastName,
+        string Email,
+        string? PrivateEmail,
+        string? PhoneNumber,
+        string? Street,
+        string? City,
+        string? Zip,
+        DateOnly Birthday,
+        DateOnly EntryDate,
+        Roles Role) : ICommand<Result>, IHasAuthorization
     {
-        public required string FirstName { get; set; }
-        public required string LastName { get; set; }
-        public required string Email { get; set; }
-        public string? PrivateEmail { get; set; }
-        public string? PhoneNumber { get; set; }
-        public string? Street { get; set; }
-        public string? City { get; set; }
-        public string? Zip { get; set; }
-        public required DateOnly Birthday { get; set; }
-        public required DateOnly EntryDate { get; set; }
-        public required Roles Role { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class CreateUserCommandHandler : IRequestHandler<CreateUserCommand>
+    public class CreateUserCommandHandler(SchulyDbContext dbContext) : ICommandHandler<CreateUserCommand, Result>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public CreateUserCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(CreateUserCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<Unit> Handle(CreateUserCommand request, CancellationToken cancellationToken)
-        {
-            var user = await _dbContext.Users.AddAsync(new Domain.User()
+            await dbContext.Users.AddAsync(new Domain.User
             {
-                FirstName = request.FirstName,
-                LastName = request.LastName,
-                Email = request.Email,
-                PrivateEmail = request.PrivateEmail,
-                PhoneNumber = request.PhoneNumber,
-                Street = request.Street,
-                City = request.City,
-                Zip = request.Zip,
-                Birthday = request.Birthday,
-                EntryDate = request.EntryDate,
-                Role = request.Role
-            });
+                FirstName = command.FirstName,
+                LastName = command.LastName,
+                Email = command.Email,
+                PrivateEmail = command.PrivateEmail,
+                PhoneNumber = command.PhoneNumber,
+                Street = command.Street,
+                City = command.City,
+                Zip = command.Zip,
+                Birthday = command.Birthday,
+                EntryDate = command.EntryDate,
+                Role = command.Role
+            }, cancellationToken);
 
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/User/DeleteUserCommand.cs
+++ b/src/Schuly.Application/Commands/User/DeleteUserCommand.cs
@@ -1,42 +1,31 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.User
 {
-    public class DeleteUserCommand : IRequest, IHasAuthorization
+    public record DeleteUserCommand(Guid UserId) : ICommand<Result>, IHasAuthorization
     {
-        public required Guid UserId { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class DeleteUserCommandHandler : IRequestHandler<DeleteUserCommand>
+    public class DeleteUserCommandHandler(SchulyDbContext dbContext) : ICommandHandler<DeleteUserCommand, Result>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public DeleteUserCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(DeleteUserCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var user = await dbContext.Users
+                .SingleOrDefaultAsync(u => u.Id == command.UserId, cancellationToken);
 
-        public async ValueTask<Unit> Handle(DeleteUserCommand request, CancellationToken cancellationToken)
-        {
-            var user = await _dbContext.Users
-                .SingleOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+            if (user == null)
+                return Result.Failure($"User with ID '{command.UserId}' not found");
 
-            if (user != null)
-            {
-                _dbContext.Users.Remove(user);
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
+            dbContext.Users.Remove(user);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Commands/User/LoginCommand.cs
+++ b/src/Schuly.Application/Commands/User/LoginCommand.cs
@@ -1,105 +1,45 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Models;
 using Schuly.Application.Services;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.User
 {
-    public class LoginCommand : IRequest<LoginResponse>
-    {
-        public required string Email { get; set; }
-        public required string Password { get; set; }
-    }
+    public record LoginCommand(string Email, string Password) : ICommand<Result<LoginDto>>;
 
-    public class LoginResponse
-    {
-        public bool Success { get; set; }
-        public string? Token { get; set; }
-        public string? Message { get; set; }
-        public UserLoginDto? User { get; set; }
-    }
+    public record LoginDto(string Token, UserLoginDto User);
 
-    public class UserLoginDto
-    {
-        public Guid Id { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public string Email { get; set; }
-        public string Role { get; set; }
-    }
+    public record UserLoginDto(Guid Id, string FirstName, string LastName, string Email, string Role);
 
-    public class LoginCommandHandler : IRequestHandler<LoginCommand, LoginResponse>
+    public class LoginCommandHandler(
+        SchulyDbContext dbContext,
+        IPasswordHashingService passwordHashingService,
+        ITokenGenerationService tokenGenerationService) : ICommandHandler<LoginCommand, Result<LoginDto>>
     {
-        private readonly SchulyDbContext _dbContext;
-        private readonly IPasswordHashingService _passwordHashingService;
-        private readonly ITokenGenerationService _tokenGenerationService;
-
-        public LoginCommandHandler(
-            SchulyDbContext dbContext,
-            IPasswordHashingService passwordHashingService,
-            ITokenGenerationService tokenGenerationService)
+        public async ValueTask<Result<LoginDto>> Handle(LoginCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-            _passwordHashingService = passwordHashingService;
-            _tokenGenerationService = tokenGenerationService;
-        }
-
-        public async ValueTask<LoginResponse> Handle(LoginCommand request, CancellationToken cancellationToken)
-        {
-            var user = await _dbContext.Users
-                .FirstOrDefaultAsync(u => u.Email == request.Email, cancellationToken);
+            var user = await dbContext.Users
+                .FirstOrDefaultAsync(u => u.Email == command.Email, cancellationToken);
 
             if (user == null)
-            {
-                return new LoginResponse
-                {
-                    Success = false,
-                    Message = "Invalid email or password"
-                };
-            }
+                return Result<LoginDto>.Failure("Invalid email or password");
 
             if (string.IsNullOrEmpty(user.PasswordHash) || string.IsNullOrEmpty(user.PasswordSalt))
-            {
-                return new LoginResponse
-                {
-                    Success = false,
-                    Message = "User account is not properly configured. Please contact an administrator."
-                };
-            }
+                return Result<LoginDto>.Failure("User account is not properly configured. Please contact an administrator.");
 
-            if (!_passwordHashingService.VerifyPassword(request.Password, user.PasswordHash, user.PasswordSalt))
-            {
-                return new LoginResponse
-                {
-                    Success = false,
-                    Message = "Invalid email or password"
-                };
-            }
+            if (!passwordHashingService.VerifyPassword(command.Password, user.PasswordHash, user.PasswordSalt))
+                return Result<LoginDto>.Failure("Invalid email or password");
 
             if (user.State != Schuly.Domain.Enums.UserState.Active)
-            {
-                return new LoginResponse
-                {
-                    Success = false,
-                    Message = "User account is inactive. Please contact an administrator."
-                };
-            }
+                return Result<LoginDto>.Failure("User account is inactive. Please contact an administrator.");
 
-            var token = _tokenGenerationService.GenerateJwtToken(user);
+            var token = tokenGenerationService.GenerateJwtToken(user);
 
-            return new LoginResponse
-            {
-                Success = true,
-                Token = token,
-                User = new UserLoginDto
-                {
-                    Id = user.Id,
-                    FirstName = user.FirstName,
-                    LastName = user.LastName,
-                    Email = user.Email,
-                    Role = user.Role.ToString()
-                }
-            };
+            return Result<LoginDto>.Success(new LoginDto(
+                token,
+                new UserLoginDto(user.Id, user.FirstName, user.LastName, user.Email, user.Role.ToString())
+            ));
         }
     }
 }

--- a/src/Schuly.Application/Commands/User/RegisterCommand.cs
+++ b/src/Schuly.Application/Commands/User/RegisterCommand.cs
@@ -1,103 +1,59 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
+using Schuly.Application.Models;
 using Schuly.Application.Services;
-using Schuly.Domain;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.User
 {
-    public class RegisterCommand : IRequest<RegisterResponse>
-    {
-        public required string FirstName { get; set; }
-        public required string LastName { get; set; }
-        public required string Email { get; set; }
-        public required string Password { get; set; }
-        public DateOnly Birthday { get; set; }
-        public DateOnly EntryDate { get; set; }
-        public Roles Role { get; set; } = Roles.Student;
-    }
+    public record RegisterCommand(
+        string FirstName,
+        string LastName,
+        string Email,
+        string Password,
+        DateOnly Birthday,
+        DateOnly EntryDate,
+        Roles Role = Roles.Student) : ICommand<Result<LoginDto>>;
 
-    public class RegisterResponse
+    public class RegisterCommandHandler(
+        SchulyDbContext dbContext,
+        IPasswordHashingService passwordHashingService,
+        ITokenGenerationService tokenGenerationService) : ICommandHandler<RegisterCommand, Result<LoginDto>>
     {
-        public bool Success { get; set; }
-        public string? Message { get; set; }
-        public UserLoginDto? User { get; set; }
-    }
-
-    public class UserRegisterDto
-    {
-        public Guid Id { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public string Email { get; set; }
-        public string Role { get; set; }
-    }
-
-    public class RegisterCommandHandler : IRequestHandler<RegisterCommand, RegisterResponse>
-    {
-        private readonly SchulyDbContext _dbContext;
-        private readonly IPasswordHashingService _passwordHashingService;
-        private readonly ITokenGenerationService _tokenGenerationService;
-
-        public RegisterCommandHandler(
-            SchulyDbContext dbContext,
-            IPasswordHashingService passwordHashingService,
-            ITokenGenerationService tokenGenerationService)
+        public async ValueTask<Result<LoginDto>> Handle(RegisterCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-            _passwordHashingService = passwordHashingService;
-            _tokenGenerationService = tokenGenerationService;
-        }
-
-        public async ValueTask<RegisterResponse> Handle(RegisterCommand request, CancellationToken cancellationToken)
-        {
-            var existingUser = await _dbContext.Users
-                .FirstOrDefaultAsync(u => u.Email == request.Email, cancellationToken);
+            var existingUser = await dbContext.Users
+                .FirstOrDefaultAsync(u => u.Email == command.Email, cancellationToken);
 
             if (existingUser != null)
-            {
-                return new RegisterResponse
-                {
-                    Success = false,
-                    Message = "User with this email already exists"
-                };
-            }
+                return Result<LoginDto>.Failure("User with this email already exists");
 
-            var (passwordHash, passwordSalt) = _passwordHashingService.HashPassword(request.Password);
+            var (passwordHash, passwordSalt) = passwordHashingService.HashPassword(command.Password);
 
             var newUser = new Schuly.Domain.User
             {
                 Id = Guid.NewGuid(),
-                FirstName = request.FirstName,
-                LastName = request.LastName,
-                Email = request.Email,
-                Birthday = request.Birthday,
-                EntryDate = request.EntryDate,
-                Role = request.Role,
+                FirstName = command.FirstName,
+                LastName = command.LastName,
+                Email = command.Email,
+                Birthday = command.Birthday,
+                EntryDate = command.EntryDate,
+                Role = command.Role,
                 State = UserState.Active,
                 PasswordHash = passwordHash,
                 PasswordSalt = passwordSalt
             };
 
-            _dbContext.Users.Add(newUser);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            dbContext.Users.Add(newUser);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            var token = _tokenGenerationService.GenerateJwtToken(newUser);
+            var token = tokenGenerationService.GenerateJwtToken(newUser);
 
-            return new RegisterResponse
-            {
-                Success = true,
-                Message = "User registered successfully",
-                User = new UserLoginDto
-                {
-                    Id = newUser.Id,
-                    FirstName = newUser.FirstName,
-                    LastName = newUser.LastName,
-                    Email = newUser.Email,
-                    Role = newUser.Role.ToString()
-                }
-            };
+            return Result<LoginDto>.Success(new LoginDto(
+                token,
+                new UserLoginDto(newUser.Id, newUser.FirstName, newUser.LastName, newUser.Email, newUser.Role.ToString())
+            ));
         }
     }
 }

--- a/src/Schuly.Application/Commands/User/UpdateUserCommand.cs
+++ b/src/Schuly.Application/Commands/User/UpdateUserCommand.cs
@@ -1,66 +1,56 @@
 using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Commands.User
 {
-    public class UpdateUserCommand : IRequest, IHasAuthorization
+    public record UpdateUserCommand(
+        Guid UserId,
+        string FirstName,
+        string LastName,
+        string Email,
+        string? PrivateEmail,
+        string? PhoneNumber,
+        string? Street,
+        string? City,
+        string? Zip,
+        DateOnly Birthday,
+        DateOnly EntryDate,
+        DateOnly? LeaveDate,
+        Roles Role) : ICommand<Result>, IHasAuthorization
     {
-        public required Guid UserId { get; set; }
-        public required string FirstName { get; set; }
-        public required string LastName { get; set; }
-        public required string Email { get; set; }
-        public string? PrivateEmail { get; set; }
-        public string? PhoneNumber { get; set; }
-        public string? Street { get; set; }
-        public string? City { get; set; }
-        public string? Zip { get; set; }
-        public required DateOnly Birthday { get; set; }
-        public required DateOnly EntryDate { get; set; }
-        public DateOnly? LeaveDate { get; set; }
-        public required Roles Role { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class UpdateUserCommandHandler : IRequestHandler<UpdateUserCommand>
+    public class UpdateUserCommandHandler(SchulyDbContext dbContext) : ICommandHandler<UpdateUserCommand, Result>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public UpdateUserCommandHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result> Handle(UpdateUserCommand command, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var user = await dbContext.Users
+                .SingleOrDefaultAsync(u => u.Id == command.UserId, cancellationToken);
 
-        public async ValueTask<Unit> Handle(UpdateUserCommand request, CancellationToken cancellationToken)
-        {
-            var user = await _dbContext.Users
-                .SingleOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+            if (user == null)
+                return Result.Failure($"User with ID '{command.UserId}' not found");
 
-            if (user != null)
-            {
-                user.FirstName = request.FirstName;
-                user.LastName = request.LastName;
-                user.Email = request.Email;
-                user.PrivateEmail = request.PrivateEmail;
-                user.PhoneNumber = request.PhoneNumber;
-                user.Street = request.Street;
-                user.City = request.City;
-                user.Zip = request.Zip;
-                user.Birthday = request.Birthday;
-                user.EntryDate = request.EntryDate;
-                user.LeaveDate = request.LeaveDate;
-                user.Role = request.Role;
+            user.FirstName = command.FirstName;
+            user.LastName = command.LastName;
+            user.Email = command.Email;
+            user.PrivateEmail = command.PrivateEmail;
+            user.PhoneNumber = command.PhoneNumber;
+            user.Street = command.Street;
+            user.City = command.City;
+            user.Zip = command.Zip;
+            user.Birthday = command.Birthday;
+            user.EntryDate = command.EntryDate;
+            user.LeaveDate = command.LeaveDate;
+            user.Role = command.Role;
 
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
+            await dbContext.SaveChangesAsync(cancellationToken);
 
-            return Unit.Value;
+            return Result.Success();
         }
     }
 }

--- a/src/Schuly.Application/Models/Result.cs
+++ b/src/Schuly.Application/Models/Result.cs
@@ -1,0 +1,29 @@
+namespace Schuly.Application.Models
+{
+    public class Result
+    {
+        private Result(bool isSuccess, string? error) { IsSuccess = isSuccess; Error = error; }
+
+        public bool IsSuccess { get; }
+        public bool IsFailure => !IsSuccess;
+        public string? Error { get; }
+
+        public static Result Success() => new(true, null);
+        public static Result Failure(string error) => new(false, error);
+        public static Result<T> Success<T>(T value) => Result<T>.Success(value);
+        public static Result<T> Failure<T>(string error) => Result<T>.Failure(error);
+    }
+
+    public class Result<T>
+    {
+        private Result(bool isSuccess, T? value, string? error) { IsSuccess = isSuccess; Value = value; Error = error; }
+
+        public bool IsSuccess { get; }
+        public bool IsFailure => !IsSuccess;
+        public T? Value { get; }
+        public string? Error { get; }
+
+        public static Result<T> Success(T value) => new(true, value, null);
+        public static Result<T> Failure(string error) => new(false, default, error);
+    }
+}

--- a/src/Schuly.Application/Queries/Absence/GetAbsenceQuery.cs
+++ b/src/Schuly.Application/Queries/Absence/GetAbsenceQuery.cs
@@ -2,30 +2,24 @@ using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.Absence
 {
-    public class GetAbsenceQuery : IRequest<AbsenceDto?>
+    public record GetAbsenceQuery(long AbsenceId) : IQuery<Result<AbsenceDto>>;
+
+    public class GetAbsenceQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetAbsenceQuery, Result<AbsenceDto>>
     {
-        public required long AbsenceId { get; set; }
-    }
-
-    public class GetAbsenceQueryHandler : IRequestHandler<GetAbsenceQuery, AbsenceDto?>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetAbsenceQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<AbsenceDto>> Handle(GetAbsenceQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var absence = await dbContext.Absences
+                .SingleOrDefaultAsync(a => a.Id == query.AbsenceId, cancellationToken);
 
-        public async ValueTask<AbsenceDto?> Handle(GetAbsenceQuery request, CancellationToken cancellationToken)
-        {
-            var absence = await _dbContext.Absences
-                .SingleOrDefaultAsync(a => a.Id == request.AbsenceId, cancellationToken);
+            if (absence == null)
+                return Result<AbsenceDto>.Failure($"Absence with ID '{query.AbsenceId}' not found");
 
-            return absence?.ToDto();
+            return Result<AbsenceDto>.Success(absence.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/Absence/GetAbsencesQuery.cs
+++ b/src/Schuly.Application/Queries/Absence/GetAbsencesQuery.cs
@@ -2,27 +2,19 @@ using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.Absence
 {
-    public class GetAbsencesQuery : IRequest<List<AbsenceDto>>
+    public record GetAbsencesQuery() : IQuery<Result<List<AbsenceDto>>>;
+
+    public class GetAbsencesQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetAbsencesQuery, Result<List<AbsenceDto>>>
     {
-    }
-
-    public class GetAbsencesQueryHandler : IRequestHandler<GetAbsencesQuery, List<AbsenceDto>>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetAbsencesQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<List<AbsenceDto>>> Handle(GetAbsencesQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<List<AbsenceDto>> Handle(GetAbsencesQuery request, CancellationToken cancellationToken)
-        {
-            var absences = await _dbContext.Absences.ToListAsync(cancellationToken);
-            return absences.ToDto();
+            var absences = await dbContext.Absences.ToListAsync(cancellationToken);
+            return Result<List<AbsenceDto>>.Success(absences.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/Agenda/GetAgendaQuery.cs
+++ b/src/Schuly.Application/Queries/Agenda/GetAgendaQuery.cs
@@ -2,30 +2,24 @@ using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.Agenda
 {
-    public class GetAgendaQuery : IRequest<AgendaEntryDto?>
+    public record GetAgendaQuery(long AgendaEntryId) : IQuery<Result<AgendaEntryDto>>;
+
+    public class GetAgendaQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetAgendaQuery, Result<AgendaEntryDto>>
     {
-        public required long AgendaEntryId { get; set; }
-    }
-
-    public class GetAgendaQueryHandler : IRequestHandler<GetAgendaQuery, AgendaEntryDto?>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetAgendaQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<AgendaEntryDto>> Handle(GetAgendaQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var agendaEntry = await dbContext.AgendaEntries
+                .SingleOrDefaultAsync(a => a.Id == query.AgendaEntryId, cancellationToken);
 
-        public async ValueTask<AgendaEntryDto?> Handle(GetAgendaQuery request, CancellationToken cancellationToken)
-        {
-            var agendaEntry = await _dbContext.AgendaEntries
-                .SingleOrDefaultAsync(a => a.Id == request.AgendaEntryId, cancellationToken);
+            if (agendaEntry == null)
+                return Result<AgendaEntryDto>.Failure($"Agenda entry with ID '{query.AgendaEntryId}' not found");
 
-            return agendaEntry?.ToDto();
+            return Result<AgendaEntryDto>.Success(agendaEntry.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/Agenda/GetAgendasQuery.cs
+++ b/src/Schuly.Application/Queries/Agenda/GetAgendasQuery.cs
@@ -2,27 +2,19 @@ using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.Agenda
 {
-    public class GetAgendasQuery : IRequest<List<AgendaEntryDto>>
+    public record GetAgendasQuery() : IQuery<Result<List<AgendaEntryDto>>>;
+
+    public class GetAgendasQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetAgendasQuery, Result<List<AgendaEntryDto>>>
     {
-    }
-
-    public class GetAgendasQueryHandler : IRequestHandler<GetAgendasQuery, List<AgendaEntryDto>>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetAgendasQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<List<AgendaEntryDto>>> Handle(GetAgendasQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<List<AgendaEntryDto>> Handle(GetAgendasQuery request, CancellationToken cancellationToken)
-        {
-            var agendaEntries = await _dbContext.AgendaEntries.ToListAsync(cancellationToken);
-            return agendaEntries.ToDto();
+            var agendaEntries = await dbContext.AgendaEntries.ToListAsync(cancellationToken);
+            return Result<List<AgendaEntryDto>>.Success(agendaEntries.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/ApplicationUser/GetApplicationUserQuery.cs
+++ b/src/Schuly.Application/Queries/ApplicationUser/GetApplicationUserQuery.cs
@@ -3,37 +3,29 @@ using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.ApplicationUser
 {
-    public class GetApplicationUserQuery : IRequest<ApplicationUserDto?>, IHasAuthorization
+    public record GetApplicationUserQuery(Guid ApplicationUserId) : IQuery<Result<ApplicationUserDto>>, IHasAuthorization
     {
-        public required Guid ApplicationUserId { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class GetApplicationUserQueryHandler : IRequestHandler<GetApplicationUserQuery, ApplicationUserDto?>
+    public class GetApplicationUserQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetApplicationUserQuery, Result<ApplicationUserDto>>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetApplicationUserQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<ApplicationUserDto>> Handle(GetApplicationUserQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<ApplicationUserDto?> Handle(GetApplicationUserQuery request, CancellationToken cancellationToken)
-        {
-            var applicationUser = await _dbContext.ApplicationUsers
+            var applicationUser = await dbContext.ApplicationUsers
                 .Include(au => au.SchoolUsers)
-                .SingleOrDefaultAsync(au => au.Id == request.ApplicationUserId, cancellationToken);
+                .SingleOrDefaultAsync(au => au.Id == query.ApplicationUserId, cancellationToken);
 
-            return applicationUser?.ToDto();
+            if (applicationUser == null)
+                return Result<ApplicationUserDto>.Failure($"ApplicationUser with ID '{query.ApplicationUserId}' not found");
+
+            return Result<ApplicationUserDto>.Success(applicationUser.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/ApplicationUser/GetApplicationUsersQuery.cs
+++ b/src/Schuly.Application/Queries/ApplicationUser/GetApplicationUsersQuery.cs
@@ -3,35 +3,26 @@ using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.ApplicationUser
 {
-    public class GetApplicationUsersQuery : IRequest<List<ApplicationUserDto>>, IHasAuthorization
+    public record GetApplicationUsersQuery() : IQuery<Result<List<ApplicationUserDto>>>, IHasAuthorization
     {
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class GetApplicationUsersQueryHandler : IRequestHandler<GetApplicationUsersQuery, List<ApplicationUserDto>>
+    public class GetApplicationUsersQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetApplicationUsersQuery, Result<List<ApplicationUserDto>>>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetApplicationUsersQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<List<ApplicationUserDto>>> Handle(GetApplicationUsersQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<List<ApplicationUserDto>> Handle(GetApplicationUsersQuery request, CancellationToken cancellationToken)
-        {
-            var applicationUsers = await _dbContext.ApplicationUsers
+            var applicationUsers = await dbContext.ApplicationUsers
                 .Include(au => au.SchoolUsers)
                 .ToListAsync(cancellationToken);
 
-            return applicationUsers.ToDto();
+            return Result<List<ApplicationUserDto>>.Success(applicationUsers.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/Class/GetClassQuery.cs
+++ b/src/Schuly.Application/Queries/Class/GetClassQuery.cs
@@ -2,27 +2,18 @@ using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.Class
 {
-    public class GetClassQuery : IRequest<ClassDto?>
+    public record GetClassQuery(Guid ClassId) : IQuery<Result<ClassDto>>;
+
+    public class GetClassQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetClassQuery, Result<ClassDto>>
     {
-        public required Guid ClassId { get; set; }
-    }
-
-    public class GetClassQueryHandler : IRequestHandler<GetClassQuery, ClassDto?>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetClassQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<ClassDto>> Handle(GetClassQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<ClassDto?> Handle(GetClassQuery request, CancellationToken cancellationToken)
-        {
-            var classEntity = await _dbContext.Classes
+            var classEntity = await dbContext.Classes
                 .Include(c => c.Students)
                     .ThenInclude(s => s.Absences)
                 .Include(c => c.Students)
@@ -30,9 +21,12 @@ namespace Schuly.Application.Queries.Class
                 .Include(c => c.Agenda)
                 .Include(c => c.Exams)
                     .ThenInclude(e => e.Grades)
-                .SingleOrDefaultAsync(c => c.Id == request.ClassId, cancellationToken);
+                .SingleOrDefaultAsync(c => c.Id == query.ClassId, cancellationToken);
 
-            return classEntity?.ToDto();
+            if (classEntity == null)
+                return Result<ClassDto>.Failure($"Class with ID '{query.ClassId}' not found");
+
+            return Result<ClassDto>.Success(classEntity.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/Class/GetClasssQuery.cs
+++ b/src/Schuly.Application/Queries/Class/GetClasssQuery.cs
@@ -2,26 +2,18 @@ using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.Class
 {
-    public class GetClasssQuery : IRequest<List<ClassDto>>
+    public record GetClassesQuery() : IQuery<Result<List<ClassDto>>>;
+
+    public class GetClassesQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetClassesQuery, Result<List<ClassDto>>>
     {
-    }
-
-    public class GetClasssQueryHandler : IRequestHandler<GetClasssQuery, List<ClassDto>>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetClasssQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<List<ClassDto>>> Handle(GetClassesQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<List<ClassDto>> Handle(GetClasssQuery request, CancellationToken cancellationToken)
-        {
-            var classes = await _dbContext.Classes
+            var classes = await dbContext.Classes
                 .Include(c => c.Students)
                     .ThenInclude(s => s.Absences)
                 .Include(c => c.Students)
@@ -30,7 +22,8 @@ namespace Schuly.Application.Queries.Class
                 .Include(c => c.Exams)
                     .ThenInclude(e => e.Grades)
                 .ToListAsync(cancellationToken);
-            return classes.ToDto();
+
+            return Result<List<ClassDto>>.Success(classes.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/Exam/GetExamQuery.cs
+++ b/src/Schuly.Application/Queries/Exam/GetExamQuery.cs
@@ -2,31 +2,25 @@ using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.Exam
 {
-    public class GetExamQuery : IRequest<ExamDto?>
+    public record GetExamQuery(long ExamId) : IQuery<Result<ExamDto>>;
+
+    public class GetExamQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetExamQuery, Result<ExamDto>>
     {
-        public required long ExamId { get; set; }
-    }
-
-    public class GetExamQueryHandler : IRequestHandler<GetExamQuery, ExamDto?>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetExamQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<ExamDto>> Handle(GetExamQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<ExamDto?> Handle(GetExamQuery request, CancellationToken cancellationToken)
-        {
-            var exam = await _dbContext.Exams
+            var exam = await dbContext.Exams
                 .Include(e => e.Grades)
-                .SingleOrDefaultAsync(e => e.Id == request.ExamId, cancellationToken);
+                .SingleOrDefaultAsync(e => e.Id == query.ExamId, cancellationToken);
 
-            return exam?.ToDto();
+            if (exam == null)
+                return Result<ExamDto>.Failure($"Exam with ID '{query.ExamId}' not found");
+
+            return Result<ExamDto>.Success(exam.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/Exam/GetExamsQuery.cs
+++ b/src/Schuly.Application/Queries/Exam/GetExamsQuery.cs
@@ -2,29 +2,22 @@ using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.Exam
 {
-    public class GetExamsQuery : IRequest<List<ExamDto>>
+    public record GetExamsQuery() : IQuery<Result<List<ExamDto>>>;
+
+    public class GetExamsQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetExamsQuery, Result<List<ExamDto>>>
     {
-    }
-
-    public class GetExamsQueryHandler : IRequestHandler<GetExamsQuery, List<ExamDto>>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetExamsQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<List<ExamDto>>> Handle(GetExamsQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<List<ExamDto>> Handle(GetExamsQuery request, CancellationToken cancellationToken)
-        {
-            var exams = await _dbContext.Exams
+            var exams = await dbContext.Exams
                 .Include(e => e.Grades)
                 .ToListAsync(cancellationToken);
-            return exams.ToDto();
+
+            return Result<List<ExamDto>>.Success(exams.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/School/GetMySchoolsQuery.cs
+++ b/src/Schuly.Application/Queries/School/GetMySchoolsQuery.cs
@@ -3,45 +3,34 @@ using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Application.Services.Interfaces;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.School
 {
-    public class GetMySchoolsQuery : IRequest<List<SchoolDto>>, IHasAuthorization
+    public record GetMySchoolsQuery() : IQuery<Result<List<SchoolDto>>>, IHasAuthorization
     {
-        public Roles GetRequiredRole()
-        {
-            return Roles.Student;
-        }
+        public Roles GetRequiredRole() => Roles.Student;
     }
 
-    public class GetMySchoolsQueryHandler : IRequestHandler<GetMySchoolsQuery, List<SchoolDto>>
+    public class GetMySchoolsQueryHandler(SchulyDbContext dbContext, IUserService userService) : IQueryHandler<GetMySchoolsQuery, Result<List<SchoolDto>>>
     {
-        private readonly SchulyDbContext _dbContext;
-        private readonly IUserService _userService;
-
-        public GetMySchoolsQueryHandler(SchulyDbContext dbContext, IUserService userService)
+        public async ValueTask<Result<List<SchoolDto>>> Handle(GetMySchoolsQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-            _userService = userService;
-        }
-
-        public async ValueTask<List<SchoolDto>> Handle(GetMySchoolsQuery request, CancellationToken cancellationToken)
-        {
-            var currentUser = await _userService.GetCurrentUserAsync(cancellationToken);
+            var currentUser = await userService.GetCurrentUserAsync(cancellationToken);
             if (currentUser == null)
-                return new List<SchoolDto>();
+                return Result<List<SchoolDto>>.Failure("User not found");
 
-            var schools = await _dbContext.SchoolUsers
+            var schools = await dbContext.SchoolUsers
                 .Where(su => su.ApplicationUserId == currentUser.Id)
                 .Include(su => su.School)
                 .Select(su => su.School!)
                 .Distinct()
                 .ToListAsync(cancellationToken);
 
-            return schools.ToDto();
+            return Result<List<SchoolDto>>.Success(schools.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/School/GetSchoolQuery.cs
+++ b/src/Schuly.Application/Queries/School/GetSchoolQuery.cs
@@ -2,30 +2,24 @@ using Mediator;
 using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.School
 {
-    public class GetSchoolQuery : IRequest<SchoolDto?>
+    public record GetSchoolQuery(long SchoolId) : IQuery<Result<SchoolDto>>;
+
+    public class GetSchoolQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetSchoolQuery, Result<SchoolDto>>
     {
-        public required long SchoolId { get; set; }
-    }
-
-    public class GetSchoolQueryHandler : IRequestHandler<GetSchoolQuery, SchoolDto?>
-    {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetSchoolQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<SchoolDto>> Handle(GetSchoolQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
+            var school = await dbContext.Schools
+                .SingleOrDefaultAsync(s => s.Id == query.SchoolId, cancellationToken);
 
-        public async ValueTask<SchoolDto?> Handle(GetSchoolQuery request, CancellationToken cancellationToken)
-        {
-            var school = await _dbContext.Schools
-                .SingleOrDefaultAsync(s => s.Id == request.SchoolId, cancellationToken);
+            if (school == null)
+                return Result<SchoolDto>.Failure($"School with ID '{query.SchoolId}' not found");
 
-            return school?.ToDto();
+            return Result<SchoolDto>.Success(school.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/School/GetSchoolsQuery.cs
+++ b/src/Schuly.Application/Queries/School/GetSchoolsQuery.cs
@@ -3,32 +3,23 @@ using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.School
 {
-    public class GetSchoolsQuery : IRequest<List<SchoolDto>>, IHasAuthorization
+    public record GetSchoolsQuery() : IQuery<Result<List<SchoolDto>>>, IHasAuthorization
     {
-        public Roles GetRequiredRole()
-        {
-            return Roles.Administrator;
-        }
+        public Roles GetRequiredRole() => Roles.Administrator;
     }
 
-    public class GetSchoolsQueryHandler : IRequestHandler<GetSchoolsQuery, List<SchoolDto>>
+    public class GetSchoolsQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetSchoolsQuery, Result<List<SchoolDto>>>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetSchoolsQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<List<SchoolDto>>> Handle(GetSchoolsQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<List<SchoolDto>> Handle(GetSchoolsQuery request, CancellationToken cancellationToken)
-        {
-            var schools = await _dbContext.Schools.ToListAsync(cancellationToken);
-            return schools.ToDto();
+            var schools = await dbContext.Schools.ToListAsync(cancellationToken);
+            return Result<List<SchoolDto>>.Success(schools.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/SchoolUser/GetSchoolUserQuery.cs
+++ b/src/Schuly.Application/Queries/SchoolUser/GetSchoolUserQuery.cs
@@ -3,39 +3,31 @@ using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.SchoolUser
 {
-    public class GetSchoolUserQuery : IRequest<SchoolUserDto?>, IHasAuthorization
+    public record GetSchoolUserQuery(long SchoolUserId) : IQuery<Result<SchoolUserDto>>, IHasAuthorization
     {
-        public required long SchoolUserId { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Student;
-        }
+        public Roles GetRequiredRole() => Roles.Student;
     }
 
-    public class GetSchoolUserQueryHandler : IRequestHandler<GetSchoolUserQuery, SchoolUserDto?>
+    public class GetSchoolUserQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetSchoolUserQuery, Result<SchoolUserDto>>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetSchoolUserQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<SchoolUserDto>> Handle(GetSchoolUserQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<SchoolUserDto?> Handle(GetSchoolUserQuery request, CancellationToken cancellationToken)
-        {
-            var schoolUser = await _dbContext.SchoolUsers
+            var schoolUser = await dbContext.SchoolUsers
                 .Include(su => su.Absences)
                 .Include(su => su.Grades)
                 .Include(su => su.Classes)
-                .SingleOrDefaultAsync(su => su.Id == request.SchoolUserId, cancellationToken);
+                .SingleOrDefaultAsync(su => su.Id == query.SchoolUserId, cancellationToken);
 
-            return schoolUser?.ToDto();
+            if (schoolUser == null)
+                return Result<SchoolUserDto>.Failure($"SchoolUser with ID '{query.SchoolUserId}' not found");
+
+            return Result<SchoolUserDto>.Success(schoolUser.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/SchoolUser/GetSchoolUsersQuery.cs
+++ b/src/Schuly.Application/Queries/SchoolUser/GetSchoolUsersQuery.cs
@@ -3,45 +3,32 @@ using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.SchoolUser
 {
-    public class GetSchoolUsersQuery : IRequest<List<SchoolUserDto>>, IHasAuthorization
+    public record GetSchoolUsersQuery(Guid? ApplicationUserId = null) : IQuery<Result<List<SchoolUserDto>>>, IHasAuthorization
     {
-        public Guid? ApplicationUserId { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Teacher;
-        }
+        public Roles GetRequiredRole() => Roles.Teacher;
     }
 
-    public class GetSchoolUsersQueryHandler : IRequestHandler<GetSchoolUsersQuery, List<SchoolUserDto>>
+    public class GetSchoolUsersQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetSchoolUsersQuery, Result<List<SchoolUserDto>>>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetSchoolUsersQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<List<SchoolUserDto>>> Handle(GetSchoolUsersQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<List<SchoolUserDto>> Handle(GetSchoolUsersQuery request, CancellationToken cancellationToken)
-        {
-            var query = _dbContext.SchoolUsers
+            var dbQuery = dbContext.SchoolUsers
                 .Include(su => su.Absences)
                 .Include(su => su.Grades)
                 .Include(su => su.Classes)
                 .AsQueryable();
 
-            if (request.ApplicationUserId.HasValue)
-            {
-                query = query.Where(su => su.ApplicationUserId == request.ApplicationUserId.Value);
-            }
+            if (query.ApplicationUserId.HasValue)
+                dbQuery = dbQuery.Where(su => su.ApplicationUserId == query.ApplicationUserId.Value);
 
-            var schoolUsers = await query.ToListAsync(cancellationToken);
-            return schoolUsers.ToDto();
+            var schoolUsers = await dbQuery.ToListAsync(cancellationToken);
+            return Result<List<SchoolUserDto>>.Success(schoolUsers.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/User/GetCurrentUserQuery.cs
+++ b/src/Schuly.Application/Queries/User/GetCurrentUserQuery.cs
@@ -2,44 +2,27 @@ using Mediator;
 using Schuly.Application.Authorization;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Application.Services.Interfaces;
 using Schuly.Domain.Enums;
 
 namespace Schuly.Application.Queries.User
 {
-    public class GetCurrentUserQuery : IRequest<CurrentUserDto?>, IHasAuthorization
+    public record GetCurrentUserQuery() : IQuery<Result<UserDto>>, IHasAuthorization
     {
-        public Roles GetRequiredRole()
-        {
-            return Roles.Student;
-        }
+        public Roles GetRequiredRole() => Roles.Student;
     }
 
-    public class CurrentUserDto
+    public class GetCurrentUserQueryHandler(IUserService userService) : IQueryHandler<GetCurrentUserQuery, Result<UserDto>>
     {
-        public UserDto User { get; set; }
-    }
-
-    public class GetCurrentUserQueryHandler : IRequestHandler<GetCurrentUserQuery, CurrentUserDto?>
-    {
-        private readonly IUserService _userService;
-
-        public GetCurrentUserQueryHandler(IUserService userService)
+        public async ValueTask<Result<UserDto>> Handle(GetCurrentUserQuery query, CancellationToken cancellationToken)
         {
-            _userService = userService;
-        }
-
-        public async ValueTask<CurrentUserDto?> Handle(GetCurrentUserQuery request, CancellationToken cancellationToken)
-        {
-            var user = await _userService.GetCurrentUserAsync(cancellationToken);
+            var user = await userService.GetCurrentUserAsync(cancellationToken);
 
             if (user == null)
-                return null;
+                return Result<UserDto>.Failure("User not found");
 
-            return new CurrentUserDto
-            {
-                User = user.ToDto()
-            };
+            return Result<UserDto>.Success(user.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/User/GetUserQuery.cs
+++ b/src/Schuly.Application/Queries/User/GetUserQuery.cs
@@ -3,39 +3,31 @@ using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.User
 {
-    public class GetUserQuery : IRequest<UserDto?>, IHasAuthorization
+    public record GetUserQuery(Guid UserId) : IQuery<Result<UserDto>>, IHasAuthorization
     {
-        public required Guid UserId { get; set; }
-
-        public Roles GetRequiredRole()
-        {
-            return Roles.Student;
-        }
+        public Roles GetRequiredRole() => Roles.Student;
     }
 
-    public class GetUserQueryHandler : IRequestHandler<GetUserQuery, UserDto?>
+    public class GetUserQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetUserQuery, Result<UserDto>>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetUserQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<UserDto>> Handle(GetUserQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<UserDto?> Handle(GetUserQuery request, CancellationToken cancellationToken)
-        {
-            var user = await _dbContext.Users
+            var user = await dbContext.Users
                 .Include(u => u.Absences)
                 .Include(u => u.Grades)
                 .Include(u => u.Classes)
-                .SingleOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+                .SingleOrDefaultAsync(u => u.Id == query.UserId, cancellationToken);
 
-            return user?.ToDto();
+            if (user == null)
+                return Result<UserDto>.Failure($"User with ID '{query.UserId}' not found");
+
+            return Result<UserDto>.Success(user.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Queries/User/GetUsersQuery.cs
+++ b/src/Schuly.Application/Queries/User/GetUsersQuery.cs
@@ -3,36 +3,28 @@ using Microsoft.EntityFrameworkCore;
 using Schuly.Application.Authorization;
 using Schuly.Application.Dtos;
 using Schuly.Application.Mappers;
+using Schuly.Application.Models;
 using Schuly.Domain.Enums;
 using Schuly.Infrastructure;
 
 namespace Schuly.Application.Queries.User
 {
-    public class GetUsersQuery : IRequest<List<UserDto>>, IHasAuthorization
+    public record GetUsersQuery() : IQuery<Result<List<UserDto>>>, IHasAuthorization
     {
-        public Roles GetRequiredRole()
-        {
-            return Roles.Teacher;
-        }
+        public Roles GetRequiredRole() => Roles.Teacher;
     }
 
-    public class GetUsersQueryHandler : IRequestHandler<GetUsersQuery, List<UserDto>>
+    public class GetUsersQueryHandler(SchulyDbContext dbContext) : IQueryHandler<GetUsersQuery, Result<List<UserDto>>>
     {
-        private readonly SchulyDbContext _dbContext;
-
-        public GetUsersQueryHandler(SchulyDbContext dbContext)
+        public async ValueTask<Result<List<UserDto>>> Handle(GetUsersQuery query, CancellationToken cancellationToken)
         {
-            _dbContext = dbContext;
-        }
-
-        public async ValueTask<List<UserDto>> Handle(GetUsersQuery request, CancellationToken cancellationToken)
-        {
-            var users = await _dbContext.Users
+            var users = await dbContext.Users
                 .Include(u => u.Absences)
                 .Include(u => u.Grades)
                 .Include(u => u.Classes)
                 .ToListAsync(cancellationToken);
-            return users.ToDto();
+
+            return Result<List<UserDto>>.Success(users.ToDto());
         }
     }
 }

--- a/src/Schuly.Application/Schuly.Application.csproj
+++ b/src/Schuly.Application/Schuly.Application.csproj
@@ -7,16 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mediator.Abstractions" Version="3.0.1" />
-    <PackageReference Include="Mediator.SourceGenerator" Version="3.0.1">
+    <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
+    <PackageReference Include="Mediator.SourceGenerator" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Schuly.Application/Services/PasswordHashingService.cs
+++ b/src/Schuly.Application/Services/PasswordHashingService.cs
@@ -1,5 +1,4 @@
 using System.Security.Cryptography;
-using System.Text;
 
 namespace Schuly.Application.Services
 {
@@ -17,21 +16,12 @@ namespace Schuly.Application.Services
 
         public (string Hash, string Salt) HashPassword(string password)
         {
-            using (var rng = new RNGCryptoServiceProvider())
-            {
-                byte[] saltBytes = new byte[SaltSize];
-                rng.GetBytes(saltBytes);
+            byte[] saltBytes = RandomNumberGenerator.GetBytes(SaltSize);
 
-                using (var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, Iterations, HashAlgorithmName.SHA256))
-                {
-                    byte[] hashBytes = pbkdf2.GetBytes(HashSize);
+            using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, Iterations, HashAlgorithmName.SHA256);
+            byte[] hashBytes = pbkdf2.GetBytes(HashSize);
 
-                    string salt = Convert.ToBase64String(saltBytes);
-                    string hash = Convert.ToBase64String(hashBytes);
-
-                    return (hash, salt);
-                }
-            }
+            return (Convert.ToBase64String(hashBytes), Convert.ToBase64String(saltBytes));
         }
 
         public bool VerifyPassword(string password, string hash, string salt)
@@ -41,20 +31,10 @@ namespace Schuly.Application.Services
                 byte[] saltBytes = Convert.FromBase64String(salt);
                 byte[] hashBytes = Convert.FromBase64String(hash);
 
-                using (var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, Iterations, HashAlgorithmName.SHA256))
-                {
-                    byte[] computedHash = pbkdf2.GetBytes(HashSize);
+                using var pbkdf2 = new Rfc2898DeriveBytes(password, saltBytes, Iterations, HashAlgorithmName.SHA256);
+                byte[] computedHash = pbkdf2.GetBytes(HashSize);
 
-                    for (int i = 0; i < HashSize; i++)
-                    {
-                        if (hashBytes[i] != computedHash[i])
-                        {
-                            return false;
-                        }
-                    }
-
-                    return true;
-                }
+                return CryptographicOperations.FixedTimeEquals(hashBytes, computedHash);
             }
             catch
             {

--- a/src/Schuly.Application/Services/UserService.cs
+++ b/src/Schuly.Application/Services/UserService.cs
@@ -7,60 +7,45 @@ using System.Security.Claims;
 
 namespace Schuly.Application.Services
 {
-    public class UserService : IUserService
+    public class UserService(IHttpContextAccessor httpContextAccessor, SchulyDbContext dbContext) : IUserService
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly SchulyDbContext _dbContext;
-
-        public UserService(IHttpContextAccessor httpContextAccessor, SchulyDbContext dbContext)
-        {
-            _httpContextAccessor = httpContextAccessor;
-            _dbContext = dbContext;
-        }
-
         public async Task<User?> GetCurrentUserAsync(CancellationToken cancellationToken = default)
         {
             var userId = GetCurrentUserId();
             if (userId == Guid.Empty)
                 return null;
 
-            return await _dbContext.Users.FindAsync([userId], cancellationToken: cancellationToken);
+            return await dbContext.Users.FindAsync([userId], cancellationToken: cancellationToken);
         }
 
         public Guid GetCurrentUserId()
         {
-            var userIdClaim = _httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier);
+            var userIdClaim = httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier);
             if (userIdClaim?.Value != null && Guid.TryParse(userIdClaim.Value, out var userId))
-            {
                 return userId;
-            }
 
             return Guid.Empty;
         }
 
         public string? GetCurrentUserEmail()
         {
-            return _httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.Email)?.Value;
+            return httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.Email)?.Value;
         }
 
-        public Schuly.Domain.Enums.Roles GetCurrentUserRole()
+        public Domain.Enums.Roles GetCurrentUserRole()
         {
-            var roleClaim = _httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.Role)?.Value;
-            if (roleClaim != null && Enum.TryParse<Schuly.Domain.Enums.Roles>(roleClaim, out var role))
-            {
+            var roleClaim = httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.Role)?.Value;
+            if (roleClaim != null && Enum.TryParse<Domain.Enums.Roles>(roleClaim, out var role))
                 return role;
-            }
 
             return Domain.Enums.Roles.Student;
         }
 
         public long GetCurrentSchoolId()
         {
-            var schoolIdClaim = _httpContextAccessor.HttpContext?.User?.FindFirst("SchoolId")?.Value;
+            var schoolIdClaim = httpContextAccessor.HttpContext?.User?.FindFirst("SchoolId")?.Value;
             if (schoolIdClaim != null && long.TryParse(schoolIdClaim, out var schoolId))
-            {
                 return schoolId;
-            }
 
             return 0;
         }
@@ -73,7 +58,7 @@ namespace Schuly.Application.Services
             if (userId == Guid.Empty || schoolId == 0)
                 return null;
 
-            return await _dbContext.SchoolUsers
+            return await dbContext.SchoolUsers
                 .FirstOrDefaultAsync(su => su.ApplicationUserId == userId && su.SchoolId == schoolId, cancellationToken);
         }
 
@@ -81,16 +66,14 @@ namespace Schuly.Application.Services
         {
             var userId = GetCurrentUserId();
             if (userId == Guid.Empty)
-                return new List<School>();
+                return [];
 
-            var schools = await _dbContext.SchoolUsers
+            return await dbContext.SchoolUsers
                 .Where(su => su.ApplicationUserId == userId)
                 .Include(su => su.School)
                 .Select(su => su.School!)
                 .Distinct()
                 .ToListAsync(cancellationToken);
-
-            return schools;
         }
     }
 }

--- a/src/Schuly.Infrastructure/Schuly.Infrastructure.csproj
+++ b/src/Schuly.Infrastructure/Schuly.Infrastructure.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Schuly.Tests/Schuly.Tests.csproj
+++ b/src/Schuly.Tests/Schuly.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TUnit" Version="1.0.0" />
+    <PackageReference Include="TUnit" Version="1.40.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Added `Result<T>` pattern for consistent error handling — no more thrown exceptions in business logic
- Migrated all 24 commands from `IRequest` to `ICommand` with **record types**
- Migrated all 15 queries from `IRequest` to `IQuery` with **record types**  
- Adopted **primary constructor DI** across all handlers, services, and controllers
- Standardized all controller responses: `result.IsSuccess ? Ok(value) : BadRequest(error)`
- Fixed `AuthorizationBehavior` to inject `IAuthorizationService` via DI (was using `new`)
- Removed `LoginResponse`/`RegisterResponse` in favor of `Result<LoginDto>`
- Removed duplicate `Mediator.SourceGenerator` from API project
- Modernized `PasswordHashingService` (secure RNG + constant-time comparison)

## Test plan

- [ ] Verify all API endpoints return consistent `Result<T>` responses
- [ ] Test login/register flows return `LoginDto` wrapped in Result
- [ ] Test authorization behavior blocks unauthorized requests
- [ ] Verify build passes with `dotnet build` (confirmed locally, 0 errors)

resolve #211