### PR TITLE
Added App Endpoint for OIDC Configuration

### DIFF
--- a/src/Schuly.API/Controllers/AppController.cs
+++ b/src/Schuly.API/Controllers/AppController.cs
@@ -1,0 +1,33 @@
+using Mediator;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Schuly.Application.Dtos;
+using Schuly.Application.Queries.App;
+
+namespace Schuly.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AppController(IMediator mediator) : ControllerBase
+    {
+        [AllowAnonymous]
+        [HttpGet]
+        [ProducesResponseType(typeof(AppDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> Get(CancellationToken cancellationToken)
+        {
+            var result = await mediator.Send(new AppQuery(), cancellationToken);
+            if (result.IsSuccess)
+                return Ok(result.Value);
+
+            return BadRequest(result.Error);
+        }
+
+        [HttpGet("test", Name = "TestEndpointWithAuth")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public IActionResult Test()
+        {
+            return Ok();
+        }
+    }
+}

--- a/src/Schuly.Application/Dtos/AppDto.cs
+++ b/src/Schuly.Application/Dtos/AppDto.cs
@@ -1,0 +1,4 @@
+namespace Schuly.Application.Dtos
+{
+    public record AppDto(string Authority, string ClientId, string RedirectUri, string PostLogoutRedirectUri, string Scope, string Version);
+}

--- a/src/Schuly.Application/Queries/App/AppQuery.cs
+++ b/src/Schuly.Application/Queries/App/AppQuery.cs
@@ -1,0 +1,24 @@
+using Mediator;
+using Microsoft.Extensions.Configuration;
+using Schuly.Application.Dtos;
+using Schuly.Application.Models;
+
+namespace Schuly.Application.Queries.App
+{
+    public record AppQuery() : IQuery<Result<AppDto>>;
+
+    public class AppQueryHandler(IConfiguration configuration) : IQueryHandler<AppQuery, Result<AppDto>>
+    {
+        public async ValueTask<Result<AppDto>> Handle(AppQuery query, CancellationToken cancellationToken)
+        {
+            return Result<AppDto>.Success(new AppDto(
+                configuration["Oidc:Authority"] ?? string.Empty,
+                configuration["Oidc:ClientId"] ?? string.Empty,
+                configuration["Oidc:RedirectUri"] ?? "http://localhost:4200/callback",
+                configuration["Oidc:PostLogoutRedirectUri"] ?? "http://localhost:4200/",
+                configuration["Oidc:Scope"] ?? "openid profile email groups picture",
+                "1.0.0"
+            ));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Added `AppController` with `GET /api/app` (AllowAnonymous) returning OIDC config for frontend
- Added `AppQuery` + `AppDto` matching Polyglot pattern exactly
- Added `GET /api/app/test` health check endpoint (requires auth)

## Test plan

- [ ] Verify `GET /api/app` returns OIDC config without authentication
- [ ] Verify `GET /api/app/test` requires authentication
- [ ] Build passes (`dotnet build` — 0 errors)