### PR TITLE
Added Plugin System

### DIFF
--- a/Schuly.API.slnx
+++ b/Schuly.API.slnx
@@ -3,5 +3,7 @@
   <Project Path="src/Schuly.Application/Schuly.Application.csproj" />
   <Project Path="src/Schuly.Domain/Schuly.Domain.csproj" />
   <Project Path="src/Schuly.Infrastructure/Schuly.Infrastructure.csproj" />
+  <Project Path="src/Schuly.Plugin.Abstractions/Schuly.Plugin.Abstractions.csproj" />
   <Project Path="src/Schuly.Tests/Schuly.Tests.csproj" />
+  <Project Path="plugins/Schuly.Plugin.Example/Schuly.Plugin.Example.csproj" />
 </Solution>

--- a/plugins/Schuly.Plugin.Example/ExamplePlugin.cs
+++ b/plugins/Schuly.Plugin.Example/ExamplePlugin.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Schuly.Plugin.Abstractions;
+
+namespace Schuly.Plugin.Example
+{
+    public class ExamplePlugin : ISchulyPlugin
+    {
+        public string Name => "Example Plugin";
+        public string Version => "1.0.0";
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddScoped<IPluginEventHandler<Schuly.Application.Commands.SchoolUser.CreateSchoolUserCommand>, OnSchoolUserCreatedHandler>();
+        }
+
+        public void ConfigureEndpoints(IEndpointRouteBuilder endpoints)
+        {
+            endpoints.MapGet("/api/plugins/example/hello", (IPluginUserContext userContext) =>
+            {
+                return Results.Ok(new { Message = "Hello from the Example Plugin!", Plugin = Name, Version });
+            }).RequireAuthorization();
+
+            endpoints.MapGet("/api/plugins/example/info", () =>
+            {
+                return Results.Ok(new { Name, Version, Description = "A sample plugin demonstrating the Schuly plugin system." });
+            }).AllowAnonymous();
+        }
+    }
+}

--- a/plugins/Schuly.Plugin.Example/OnSchoolUserCreatedHandler.cs
+++ b/plugins/Schuly.Plugin.Example/OnSchoolUserCreatedHandler.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Logging;
+using Schuly.Application.Commands.SchoolUser;
+using Schuly.Plugin.Abstractions;
+
+namespace Schuly.Plugin.Example
+{
+    public class OnSchoolUserCreatedHandler(ILogger<OnSchoolUserCreatedHandler> logger) : IPluginEventHandler<CreateSchoolUserCommand>
+    {
+        public Task HandleAsync(CreateSchoolUserCommand command, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("Example Plugin: SchoolUser '{FirstName} {LastName}' was created!", command.FirstName, command.LastName);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/plugins/Schuly.Plugin.Example/Schuly.Plugin.Example.csproj
+++ b/plugins/Schuly.Plugin.Example/Schuly.Plugin.Example.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Schuly.Plugin.Abstractions\Schuly.Plugin.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Schuly.Application\Schuly.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Schuly.API/Extensions/PluginExtensions.cs
+++ b/src/Schuly.API/Extensions/PluginExtensions.cs
@@ -1,0 +1,69 @@
+using Schuly.Plugin.Abstractions;
+using System.Reflection;
+
+namespace Schuly.API.Extensions
+{
+    public static class PluginExtensions
+    {
+        public static IServiceCollection AddPlugins(this IServiceCollection services, IConfiguration configuration)
+        {
+            var plugins = DiscoverPlugins(configuration);
+
+            foreach (var plugin in plugins)
+            {
+                plugin.ConfigureServices(services);
+            }
+
+            services.AddSingleton<IReadOnlyList<ISchulyPlugin>>(plugins);
+
+            return services;
+        }
+
+        public static WebApplication UsePlugins(this WebApplication app)
+        {
+            var plugins = app.Services.GetRequiredService<IReadOnlyList<ISchulyPlugin>>();
+
+            foreach (var plugin in plugins)
+            {
+                plugin.ConfigureEndpoints(app);
+                app.Logger.LogInformation("Loaded plugin: {Name} v{Version}", plugin.Name, plugin.Version);
+            }
+
+            return app;
+        }
+
+        private static List<ISchulyPlugin> DiscoverPlugins(IConfiguration configuration)
+        {
+            var plugins = new List<ISchulyPlugin>();
+            var pluginDir = configuration["Plugins:Directory"] ?? "plugins";
+
+            if (!Path.IsPathRooted(pluginDir))
+                pluginDir = Path.Combine(AppContext.BaseDirectory, pluginDir);
+
+            if (!Directory.Exists(pluginDir))
+                return plugins;
+
+            foreach (var dll in Directory.GetFiles(pluginDir, "*.dll"))
+            {
+                try
+                {
+                    var assembly = Assembly.LoadFrom(dll);
+                    var pluginTypes = assembly.GetTypes()
+                        .Where(t => typeof(ISchulyPlugin).IsAssignableFrom(t) && t is { IsAbstract: false, IsInterface: false });
+
+                    foreach (var type in pluginTypes)
+                    {
+                        if (Activator.CreateInstance(type) is ISchulyPlugin plugin)
+                            plugins.Add(plugin);
+                    }
+                }
+                catch
+                {
+                    // Skip DLLs that can't be loaded
+                }
+            }
+
+            return plugins;
+        }
+    }
+}

--- a/src/Schuly.API/Program.cs
+++ b/src/Schuly.API/Program.cs
@@ -3,8 +3,10 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi;
 using Schuly.API.Extensions;
+using Schuly.API.Services;
 using Schuly.Infrastructure;
 using Schuly.Infrastructure.Services;
+using Schuly.Plugin.Abstractions;
 using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -65,7 +67,10 @@ builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddScoped<IOidcService, OidcService>();
 builder.Services.AddScoped<IUserService, UserService>();
+builder.Services.AddScoped<IPluginUserContext, PluginUserContext>();
 builder.Services.AddScoped<Schuly.Application.Authorization.IAppAuthorizationService, Schuly.Application.Authorization.AuthorizationService>();
+
+builder.Services.AddPlugins(builder.Configuration);
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
@@ -101,5 +106,6 @@ if (app.Environment.IsDevelopment())
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
+app.UsePlugins();
 
 app.Run();

--- a/src/Schuly.API/Schuly.API.csproj
+++ b/src/Schuly.API/Schuly.API.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Schuly.Application\Schuly.Application.csproj" />
     <ProjectReference Include="..\Schuly.Infrastructure\Schuly.Infrastructure.csproj" />
+    <ProjectReference Include="..\Schuly.Plugin.Abstractions\Schuly.Plugin.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Schuly.API/Services/PluginUserContext.cs
+++ b/src/Schuly.API/Services/PluginUserContext.cs
@@ -1,0 +1,19 @@
+using Schuly.Infrastructure.Services;
+using Schuly.Plugin.Abstractions;
+
+namespace Schuly.API.Services
+{
+    public class PluginUserContext(IUserService userService) : IPluginUserContext
+    {
+        public async Task<Guid> GetCurrentUserIdAsync(CancellationToken cancellationToken = default)
+        {
+            return await userService.GetCurrentUserIdAsync(cancellationToken);
+        }
+
+        public Task<Guid?> GetCurrentSchoolUserIdAsync(CancellationToken cancellationToken = default)
+        {
+            // TODO: implement when school context selection is added
+            return Task.FromResult<Guid?>(null);
+        }
+    }
+}

--- a/src/Schuly.Application/Behaviors/PluginEventBehavior.cs
+++ b/src/Schuly.Application/Behaviors/PluginEventBehavior.cs
@@ -1,0 +1,64 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Schuly.Plugin.Abstractions;
+
+namespace Schuly.Application.Behaviors
+{
+    public class PluginEventBehavior<TRequest, TResponse>(IServiceProvider serviceProvider, ILogger<PluginEventBehavior<TRequest, TResponse>> logger) : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : notnull, IMessage
+    {
+        public async ValueTask<TResponse> Handle(
+            TRequest request,
+            MessageHandlerDelegate<TRequest, TResponse> next,
+            CancellationToken cancellationToken)
+        {
+            var response = await next(request, cancellationToken);
+
+            if (IsSuccessResult(response))
+            {
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        using var scope = serviceProvider.CreateScope();
+                        var handlers = scope.ServiceProvider.GetServices<IPluginEventHandler<TRequest>>();
+
+                        foreach (var handler in handlers)
+                        {
+                            try
+                            {
+                                await handler.HandleAsync(request, CancellationToken.None);
+                            }
+                            catch (Exception ex)
+                            {
+                                logger.LogError(ex, "Plugin event handler {Handler} failed for {Command}", handler.GetType().Name, typeof(TRequest).Name);
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Plugin event dispatch failed for {Command}", typeof(TRequest).Name);
+                    }
+                }, CancellationToken.None);
+            }
+
+            return response;
+        }
+
+        private static bool IsSuccessResult(TResponse response)
+        {
+            if (response is Models.Result result)
+                return result.IsSuccess;
+
+            var type = typeof(TResponse);
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Models.Result<>))
+            {
+                var prop = type.GetProperty("IsSuccess");
+                return prop?.GetValue(response) is true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Schuly.Application/Schuly.Application.csproj
+++ b/src/Schuly.Application/Schuly.Application.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Schuly.Domain\Schuly.Domain.csproj" />
     <ProjectReference Include="..\Schuly.Infrastructure\Schuly.Infrastructure.csproj" />
+    <ProjectReference Include="..\Schuly.Plugin.Abstractions\Schuly.Plugin.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Schuly.Plugin.Abstractions/IPluginEventHandler.cs
+++ b/src/Schuly.Plugin.Abstractions/IPluginEventHandler.cs
@@ -1,0 +1,7 @@
+namespace Schuly.Plugin.Abstractions
+{
+    public interface IPluginEventHandler<in TCommand>
+    {
+        Task HandleAsync(TCommand command, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Schuly.Plugin.Abstractions/IPluginUserContext.cs
+++ b/src/Schuly.Plugin.Abstractions/IPluginUserContext.cs
@@ -1,0 +1,8 @@
+namespace Schuly.Plugin.Abstractions
+{
+    public interface IPluginUserContext
+    {
+        Task<Guid> GetCurrentUserIdAsync(CancellationToken cancellationToken = default);
+        Task<Guid?> GetCurrentSchoolUserIdAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Schuly.Plugin.Abstractions/ISchulyPlugin.cs
+++ b/src/Schuly.Plugin.Abstractions/ISchulyPlugin.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Schuly.Plugin.Abstractions
+{
+    public interface ISchulyPlugin
+    {
+        string Name { get; }
+        string Version { get; }
+        void ConfigureServices(IServiceCollection services);
+        void ConfigureEndpoints(IEndpointRouteBuilder endpoints);
+    }
+}

--- a/src/Schuly.Plugin.Abstractions/Schuly.Plugin.Abstractions.csproj
+++ b/src/Schuly.Plugin.Abstractions/Schuly.Plugin.Abstractions.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageId>Schuly.Plugin.Abstractions</PackageId>
+    <Description>Abstractions for building Schuly plugins</Description>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Schuly.Infrastructure\Schuly.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Schuly.Tests/Schuly.Tests.csproj
+++ b/src/Schuly.Tests/Schuly.Tests.csproj
@@ -16,6 +16,8 @@
     <ProjectReference Include="../Schuly.Domain/Schuly.Domain.csproj" />
     <ProjectReference Include="../Schuly.Infrastructure/Schuly.Infrastructure.csproj" />
     <ProjectReference Include="../Schuly.API/Schuly.API.csproj" />
+    <ProjectReference Include="../Schuly.Plugin.Abstractions/Schuly.Plugin.Abstractions.csproj" />
+    <ProjectReference Include="../../plugins/Schuly.Plugin.Example/Schuly.Plugin.Example.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Schuly.Tests/UnitTest1.cs
+++ b/src/Schuly.Tests/UnitTest1.cs
@@ -1,18 +1,37 @@
+using Schuly.Plugin.Abstractions;
+using Schuly.Plugin.Example;
+
 namespace Schuly.Tests;
 
-public class UnitTest1
+public class PluginSystemTests
 {
     [Test]
-    public async Task Test_Example()
+    public async Task ExamplePlugin_ImplementsInterface()
     {
-        // Arrange
-        int a = 5;
-        int b = 10;
+        var plugin = new ExamplePlugin();
 
-        // Act
-        int result = a + b;
+        await Assert.That(plugin).IsAssignableTo<ISchulyPlugin>();
+        await Assert.That(plugin.Name).IsEqualTo("Example Plugin");
+        await Assert.That(plugin.Version).IsEqualTo("1.0.0");
+    }
 
-        // Assert
-        await Assert.That(result).IsEqualTo(15);
+    [Test]
+    public async Task ExamplePlugin_ConfigureServices_DoesNotThrow()
+    {
+        var plugin = new ExamplePlugin();
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+
+        plugin.ConfigureServices(services);
+
+        await Assert.That(services.Count).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task OnSchoolUserCreatedHandler_ImplementsEventHandler()
+    {
+        var handlerType = typeof(OnSchoolUserCreatedHandler);
+        var interfaceType = typeof(IPluginEventHandler<Schuly.Application.Commands.SchoolUser.CreateSchoolUserCommand>);
+
+        await Assert.That(interfaceType.IsAssignableFrom(handlerType)).IsTrue();
     }
 }


### PR DESCRIPTION
## Summary

- Added `Schuly.Plugin.Abstractions` project with plugin interfaces
- Added `PluginEventBehavior` — Mediator pipeline that fires plugin event handlers after successful commands (fire-and-forget, isolated per-handler error handling)
- Added `PluginExtensions` for auto-discovery of plugin DLLs from `plugins/` directory
- Added `IPluginUserContext` for plugins to access current user identity
- Added `Schuly.Plugin.Example` demonstrating endpoints + event hooks
- 3 tests passing

## How to build a plugin

1. Create a class library referencing `Schuly.Plugin.Abstractions`
2. Implement `ISchulyPlugin` (register services, map endpoints)
3. Implement `IPluginEventHandler<TCommand>` to react to any command
4. Drop the DLL in `plugins/` — auto-discovered on startup

## Test plan

- [x] Build passes (0 errors)
- [x] 3 plugin tests pass (interface impl, service registration, event handler type check)
- [ ] Drop example plugin DLL in plugins/ and verify endpoints load
- [ ] Verify event handler fires on SchoolUser creation