### PR TITLE
Added Multi-School Schulware Account Support

### DIFF
--- a/plugins/Schuly.Plugin.Schulware/Data/SchulwareDbContext.cs
+++ b/plugins/Schuly.Plugin.Schulware/Data/SchulwareDbContext.cs
@@ -4,34 +4,45 @@ namespace Schuly.Plugin.Schulware.Data
 {
     public class SchulwareDbContext(DbContextOptions<SchulwareDbContext> options) : DbContext(options)
     {
-        public DbSet<SchulwareCredential> Credentials { get; set; }
+        public DbSet<SchulwareAccount> Accounts { get; set; }
         public DbSet<SyncState> SyncStates { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<SchulwareCredential>(entity =>
+            modelBuilder.Entity<SchulwareAccount>(entity =>
             {
-                entity.HasKey(c => c.Id);
-                entity.HasIndex(c => c.ApplicationUserId).IsUnique();
+                entity.HasKey(a => a.Id);
+                entity.HasIndex(a => new { a.ApplicationUserId, a.SchulnetzBaseUrl }).IsUnique();
             });
 
             modelBuilder.Entity<SyncState>(entity =>
             {
                 entity.HasKey(s => s.Id);
-                entity.HasIndex(s => s.ApplicationUserId).IsUnique();
+                entity.HasIndex(s => s.AccountId).IsUnique();
+                entity.HasOne(s => s.Account).WithOne().HasForeignKey<SyncState>(s => s.AccountId);
             });
         }
     }
 
-    public class SchulwareCredential
+    public class SchulwareAccount
     {
         public Guid Id { get; set; }
         public Guid ApplicationUserId { get; set; }
+        public Guid? SchoolUserId { get; set; }
+
+        public required string SchulnetzBaseUrl { get; set; }
+        public required string SchulwareApiBaseUrl { get; set; }
+        public string? SchulnetzStudentId { get; set; }
+        public string? DisplayName { get; set; }
+
         public string? MobileAccessToken { get; set; }
         public string? MobileRefreshToken { get; set; }
         public DateTime? MobileTokenExpiresAt { get; set; }
+
         public string? WebSessionId { get; set; }
-        public string? WebNavigationUrlsJson { get; set; }
+        public string? WebSessionUserId { get; set; }
+        public string? WebSessionTransId { get; set; }
+
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime UpdatedAt { get; set; }
     }
@@ -39,7 +50,8 @@ namespace Schuly.Plugin.Schulware.Data
     public class SyncState
     {
         public Guid Id { get; set; }
-        public Guid ApplicationUserId { get; set; }
+        public Guid AccountId { get; set; }
+        public SchulwareAccount? Account { get; set; }
         public DateTime? LastSyncAt { get; set; }
         public string? LastSyncStatus { get; set; }
         public string? LastSyncError { get; set; }

--- a/plugins/Schuly.Plugin.Schulware/SchulwarePlugin.cs
+++ b/plugins/Schuly.Plugin.Schulware/SchulwarePlugin.cs
@@ -9,159 +9,234 @@ using Schuly.Plugin.Abstractions;
 using Schuly.Plugin.Schulware.Client;
 using Schuly.Plugin.Schulware.Client.Models;
 using Schuly.Plugin.Schulware.Data;
-using System.Text.Json;
+using System.Net.Http.Json;
 
 namespace Schuly.Plugin.Schulware
 {
     public class SchulwarePlugin : ISchulyPlugin
     {
         public string Name => "Schulware Integration";
-        public string Version => "1.0.0";
+        public string Version => "2.0.0";
 
         public void ConfigureServices(IServiceCollection services, PluginServiceContext context)
         {
             services.AddDbContext<SchulwareDbContext>(options =>
                 options.UseNpgsql(context.ConnectionString));
 
-            var baseUrl = context.Configuration["SchulwareApi:BaseUrl"] ?? "https://schlwr.pianonic.ch";
-
-            services.AddScoped(sp =>
-            {
-                var httpClient = sp.GetRequiredService<IHttpClientFactory>().CreateClient("Schulware");
-                var adapter = new HttpClientRequestAdapter(new AnonymousAuthenticationProvider(), httpClient: httpClient);
-                adapter.BaseUrl = baseUrl;
-                return new SchulwareApiClient(adapter);
-            });
-
             services.AddSingleton<IPluginBackgroundTask, SchulwareSyncTask>();
         }
 
         public void ConfigureEndpoints(IEndpointRouteBuilder endpoints)
         {
-            endpoints.MapGet("/api/plugins/schulware/info", async (SchulwareApiClient client) =>
-            {
-                var info = await client.Api.App.AppInfo.GetAsync();
-                return Results.Ok(info);
-            }).AllowAnonymous();
-
             endpoints.MapGet("/api/plugins/schulware/status", () =>
-            {
-                return Results.Ok(new { Status = "Connected", Plugin = Name, Version });
-            }).AllowAnonymous();
+                Results.Ok(new { Status = "Active", Plugin = Name, Version })
+            ).AllowAnonymous();
 
-            endpoints.MapPost("/api/plugins/schulware/auth/unified", async (
-                AuthenticateRequestDto request,
+            endpoints.MapGet("/api/plugins/schulware/accounts", async (
                 IPluginUserContext userContext,
-                SchulwareDbContext db,
-                SchulwareApiClient client) =>
+                SchulwareDbContext db) =>
             {
                 var userId = await userContext.GetCurrentUserIdAsync();
-                var result = await client.Api.Authenticate.Unified.PostAsync(request);
-
-                if (result is null || result.Success != true)
-                    return Results.BadRequest(result?.Message ?? "Unified authentication failed");
-
-                await UpsertCredential(db, userId, credential =>
-                {
-                    credential.MobileAccessToken = result.AccessToken;
-                    credential.MobileRefreshToken = result.RefreshToken;
-                    credential.MobileTokenExpiresAt = DateTime.UtcNow.AddHours(1);
-                });
-
-                return Results.Ok(new { Success = true, Message = "Schulware unified credentials stored" });
+                var accounts = await db.Accounts
+                    .Where(a => a.ApplicationUserId == userId)
+                    .Select(a => new
+                    {
+                        a.Id, a.SchulnetzBaseUrl, a.DisplayName, a.SchulnetzStudentId,
+                        a.SchoolUserId, HasMobileToken = a.MobileAccessToken != null,
+                        HasWebSession = a.WebSessionId != null, a.MobileTokenExpiresAt, a.CreatedAt
+                    })
+                    .ToListAsync();
+                return Results.Ok(accounts);
             }).RequireAuthorization();
 
-            endpoints.MapPost("/api/plugins/schulware/auth/mobile", async (
-                AuthenticateRequestDto request,
+            endpoints.MapPost("/api/plugins/schulware/accounts", async (
+                ConnectAccountRequest request,
                 IPluginUserContext userContext,
-                SchulwareDbContext db,
-                SchulwareApiClient client) =>
+                SchulwareDbContext db) =>
             {
                 var userId = await userContext.GetCurrentUserIdAsync();
-                var body = new Body_authenticateMobile { Email = request.Email, Password = request.Password };
-                var result = await client.Api.Authenticate.Mobile.PostAsync(body);
 
-                if (result is null || result.Success != true)
-                    return Results.BadRequest(result?.Message ?? "Mobile authentication failed");
+                var exists = await db.Accounts.AnyAsync(a =>
+                    a.ApplicationUserId == userId && a.SchulnetzBaseUrl == request.SchulnetzBaseUrl);
+                if (exists)
+                    return Results.BadRequest("Account for this Schulnetz instance already connected");
 
-                await UpsertCredential(db, userId, credential =>
+                var account = new SchulwareAccount
                 {
-                    credential.MobileAccessToken = result.AccessToken;
-                    credential.MobileRefreshToken = result.RefreshToken;
-                    credential.MobileTokenExpiresAt = DateTime.UtcNow.AddHours(1);
-                });
+                    ApplicationUserId = userId,
+                    SchulnetzBaseUrl = request.SchulnetzBaseUrl,
+                    SchulwareApiBaseUrl = request.SchulwareApiBaseUrl ?? "https://schlwr.pianonic.ch",
+                    DisplayName = request.DisplayName,
+                    SchoolUserId = request.SchoolUserId,
+                };
+                db.Accounts.Add(account);
+                await db.SaveChangesAsync();
 
-                return Results.Ok(new { Success = true, Message = "Schulware mobile credentials stored" });
+                return Results.Ok(new { account.Id, Message = "Account created. Authenticate next." });
             }).RequireAuthorization();
 
-            endpoints.MapGet("/api/plugins/schulware/auth/oauth/url", async (SchulwareApiClient client) =>
+            endpoints.MapDelete("/api/plugins/schulware/accounts/{accountId:guid}", async (
+                Guid accountId,
+                IPluginUserContext userContext,
+                SchulwareDbContext db) =>
             {
+                var userId = await userContext.GetCurrentUserIdAsync();
+                var account = await db.Accounts.FirstOrDefaultAsync(a => a.Id == accountId && a.ApplicationUserId == userId);
+                if (account is null) return Results.NotFound();
+
+                var syncState = await db.SyncStates.FirstOrDefaultAsync(s => s.AccountId == accountId);
+                if (syncState is not null) db.SyncStates.Remove(syncState);
+
+                db.Accounts.Remove(account);
+                await db.SaveChangesAsync();
+                return Results.NoContent();
+            }).RequireAuthorization();
+
+            endpoints.MapGet("/api/plugins/schulware/accounts/{accountId:guid}/auth/oauth/url", async (
+                Guid accountId,
+                IPluginUserContext userContext,
+                SchulwareDbContext db,
+                IHttpClientFactory httpClientFactory) =>
+            {
+                var userId = await userContext.GetCurrentUserIdAsync();
+                var account = await db.Accounts.FirstOrDefaultAsync(a => a.Id == accountId && a.ApplicationUserId == userId);
+                if (account is null) return Results.NotFound();
+
+                var client = CreateClient(httpClientFactory, account.SchulwareApiBaseUrl);
                 var result = await client.Api.Authenticate.Oauth.Mobile.Url.GetAsync();
                 return Results.Ok(result);
             }).RequireAuthorization();
 
-            endpoints.MapPost("/api/plugins/schulware/auth/oauth/callback", async (
-                MobileCallbackRequestDto request,
+            endpoints.MapPost("/api/plugins/schulware/accounts/{accountId:guid}/auth/oauth/callback", async (
+                Guid accountId,
+                OAuthCallbackRequest request,
                 IPluginUserContext userContext,
                 SchulwareDbContext db,
-                SchulwareApiClient client) =>
+                IHttpClientFactory httpClientFactory,
+                Schuly.Infrastructure.SchulyDbContext mainDb) =>
             {
                 var userId = await userContext.GetCurrentUserIdAsync();
-                var result = await client.Api.Authenticate.Oauth.Mobile.Callback.PostAsync(request);
+                var account = await db.Accounts.FirstOrDefaultAsync(a => a.Id == accountId && a.ApplicationUserId == userId);
+                if (account is null) return Results.NotFound();
 
-                if (result is null)
-                    return Results.BadRequest("OAuth callback failed");
+                using var httpClient = httpClientFactory.CreateClient("Schulware");
 
-                await UpsertCredential(db, userId, credential =>
+                // 1. Exchange code for tokens
+                var callbackRes = await httpClient.PostAsJsonAsync(
+                    $"{account.SchulwareApiBaseUrl}/api/authenticate/oauth/mobile/callback",
+                    new { code = request.Code, code_verifier = request.CodeVerifier, state = request.State });
+
+                if (!callbackRes.IsSuccessStatusCode)
+                    return Results.BadRequest($"OAuth callback failed: {await callbackRes.Content.ReadAsStringAsync()}");
+
+                var tokenResult = await callbackRes.Content.ReadFromJsonAsync<TokenResponse>();
+                if (tokenResult is null)
+                    return Results.BadRequest("Failed to parse token response");
+
+                account.MobileAccessToken = tokenResult.AccessToken;
+                account.MobileRefreshToken = tokenResult.RefreshToken;
+                account.MobileTokenExpiresAt = DateTime.UtcNow.AddHours(1);
+
+                // 2. Capture web session
+                var captureRes = await httpClient.PostAsJsonAsync(
+                    $"{account.SchulwareApiBaseUrl}/api/websession/capture",
+                    new { code = request.Code, state = request.State ?? "" });
+
+                if (captureRes.IsSuccessStatusCode)
                 {
-                    credential.MobileAccessToken = result.AccessToken;
-                    credential.MobileRefreshToken = result.RefreshToken;
-                    credential.MobileTokenExpiresAt = DateTime.UtcNow.AddHours(1);
-                });
-
-                return Results.Ok(new { Success = true, Message = "Schulware OAuth credentials stored" });
-            }).RequireAuthorization();
-
-            endpoints.MapDelete("/api/plugins/schulware/auth", async (
-                IPluginUserContext userContext,
-                SchulwareDbContext db) =>
-            {
-                var userId = await userContext.GetCurrentUserIdAsync();
-                var credential = await db.Credentials.FirstOrDefaultAsync(c => c.ApplicationUserId == userId);
-
-                if (credential is not null)
-                {
-                    db.Credentials.Remove(credential);
-                    await db.SaveChangesAsync();
+                    var sessionResult = await captureRes.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+                    if (sessionResult.TryGetProperty("success", out var success) && success.GetBoolean())
+                    {
+                        account.WebSessionId = sessionResult.TryGetProperty("session_id", out var sid) ? sid.GetString() : null;
+                        if (sessionResult.TryGetProperty("session_info", out var info) && info.ValueKind == System.Text.Json.JsonValueKind.Object)
+                        {
+                            account.WebSessionUserId = info.TryGetProperty("id", out var id) ? id.GetString() : null;
+                            account.WebSessionTransId = info.TryGetProperty("transid", out var tid) ? tid.GetString() : null;
+                        }
+                    }
                 }
 
-                return Results.NoContent();
+                // 3. Fetch user info and auto-provision School + SchoolUser
+                if (account.SchoolUserId is null && account.MobileAccessToken is not null)
+                {
+                    try
+                    {
+                        httpClient.DefaultRequestHeaders.Authorization =
+                            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", account.MobileAccessToken);
+
+                        var userInfoRes = await httpClient.GetAsync($"{account.SchulwareApiBaseUrl}/api/mobile/userInfo");
+                        if (userInfoRes.IsSuccessStatusCode)
+                        {
+                            var userInfo = await userInfoRes.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+
+                            var schoolName = account.DisplayName ?? account.SchulnetzBaseUrl;
+                            var school = await mainDb.Schools.FirstOrDefaultAsync(s => s.Name == schoolName);
+                            if (school is null)
+                            {
+                                school = new Schuly.Domain.School { Name = schoolName };
+                                mainDb.Schools.Add(school);
+                                await mainDb.SaveChangesAsync();
+                            }
+
+                            var firstName = userInfo.TryGetProperty("firstName", out var fn) ? fn.GetString() ?? "" : "";
+                            var lastName = userInfo.TryGetProperty("lastName", out var ln) ? ln.GetString() ?? "" : "";
+                            var email = userInfo.TryGetProperty("email", out var em) ? em.GetString() ?? "" : "";
+                            var studentId = userInfo.TryGetProperty("idNr", out var idNr) ? idNr.GetString() : null;
+                            var birthday = userInfo.TryGetProperty("birthday", out var bd) ? bd.GetString() : null;
+                            var entryDate = userInfo.TryGetProperty("entryDate", out var ed) ? ed.GetString() : null;
+
+                            var schoolUser = await mainDb.SchoolUsers
+                                .FirstOrDefaultAsync(su => su.ApplicationUserId == userId && su.SchoolId == school.Id);
+
+                            if (schoolUser is null)
+                            {
+                                schoolUser = new Schuly.Domain.SchoolUser
+                                {
+                                    ApplicationUserId = userId,
+                                    SchoolId = school.Id,
+                                    FirstName = firstName,
+                                    LastName = lastName,
+                                    Email = email,
+                                    Birthday = DateOnly.TryParse(birthday, out var bd2) ? bd2 : DateOnly.FromDateTime(DateTime.UtcNow),
+                                    EntryDate = DateOnly.TryParse(entryDate, out var ed2) ? ed2 : DateOnly.FromDateTime(DateTime.UtcNow),
+                                    Role = Schuly.Domain.Enums.Roles.Student,
+                                };
+                                mainDb.SchoolUsers.Add(schoolUser);
+                                await mainDb.SaveChangesAsync();
+                            }
+
+                            account.SchoolUserId = schoolUser.Id;
+                            account.SchulnetzStudentId = studentId;
+                        }
+                    }
+                    catch { }
+                }
+
+                account.UpdatedAt = DateTime.UtcNow;
+                await db.SaveChangesAsync();
+
+                return Results.Ok(new { Success = true, Message = "Authenticated and session captured" });
             }).RequireAuthorization();
 
-            endpoints.MapGet("/api/plugins/schulware/auth/status", async (
+            endpoints.MapGet("/api/plugins/schulware/accounts/{accountId:guid}/sync", async (
+                Guid accountId,
                 IPluginUserContext userContext,
                 SchulwareDbContext db) =>
             {
                 var userId = await userContext.GetCurrentUserIdAsync();
-                var credential = await db.Credentials.FirstOrDefaultAsync(c => c.ApplicationUserId == userId);
+                var account = await db.Accounts.FirstOrDefaultAsync(a => a.Id == accountId && a.ApplicationUserId == userId);
+                if (account is null) return Results.NotFound();
 
-                if (credential is null)
-                    return Results.Ok(new { Connected = false });
-
+                var syncState = await db.SyncStates.FirstOrDefaultAsync(s => s.AccountId == accountId);
                 return Results.Ok(new
                 {
-                    Connected = true,
-                    HasMobileToken = credential.MobileAccessToken is not null,
-                    HasWebSession = credential.WebSessionId is not null,
-                    MobileTokenExpires = credential.MobileTokenExpiresAt,
-                    LastUpdated = credential.UpdatedAt
+                    account.Id, account.SchulnetzBaseUrl, account.DisplayName,
+                    HasMobileToken = account.MobileAccessToken is not null,
+                    HasWebSession = account.WebSessionId is not null,
+                    LastSync = syncState?.LastSyncAt,
+                    SyncStatus = syncState?.LastSyncStatus,
+                    SyncError = syncState?.LastSyncError,
                 });
-            }).RequireAuthorization();
-
-            endpoints.MapGet("/api/plugins/schulware/sync-status", async (SchulwareDbContext db) =>
-            {
-                var states = await db.SyncStates.ToListAsync();
-                return Results.Ok(states);
             }).RequireAuthorization();
         }
 
@@ -172,18 +247,24 @@ namespace Schuly.Plugin.Schulware
             await db.Database.EnsureCreatedAsync(cancellationToken);
         }
 
-        private static async Task UpsertCredential(SchulwareDbContext db, Guid userId, Action<SchulwareCredential> update)
+        internal static SchulwareApiClient CreateClient(IHttpClientFactory httpClientFactory, string baseUrl)
         {
-            var credential = await db.Credentials.FirstOrDefaultAsync(c => c.ApplicationUserId == userId);
-            if (credential is null)
-            {
-                credential = new SchulwareCredential { ApplicationUserId = userId };
-                db.Credentials.Add(credential);
-            }
-
-            update(credential);
-            credential.UpdatedAt = DateTime.UtcNow;
-            await db.SaveChangesAsync();
+            var httpClient = httpClientFactory.CreateClient("Schulware");
+            var adapter = new HttpClientRequestAdapter(new AnonymousAuthenticationProvider(), httpClient: httpClient);
+            adapter.BaseUrl = baseUrl;
+            return new SchulwareApiClient(adapter);
         }
     }
+
+    public record ConnectAccountRequest(
+        string SchulnetzBaseUrl,
+        string? SchulwareApiBaseUrl,
+        string? DisplayName,
+        Guid? SchoolUserId);
+
+    public record OAuthCallbackRequest(string Code, string CodeVerifier, string? State);
+
+    public record TokenResponse(
+        [property: System.Text.Json.Serialization.JsonPropertyName("access_token")] string? AccessToken,
+        [property: System.Text.Json.Serialization.JsonPropertyName("refresh_token")] string? RefreshToken);
 }

--- a/plugins/Schuly.Plugin.Schulware/SchulwareSyncTask.cs
+++ b/plugins/Schuly.Plugin.Schulware/SchulwareSyncTask.cs
@@ -1,6 +1,11 @@
+using System.Net.Http.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Kiota.Abstractions.Authentication;
+using Microsoft.Kiota.Http.HttpClientLibrary;
+using Schuly.Domain;
+using Schuly.Domain.Enums;
 using Schuly.Plugin.Abstractions;
 using Schuly.Plugin.Schulware.Client;
 using Schuly.Plugin.Schulware.Data;
@@ -16,34 +21,60 @@ namespace Schuly.Plugin.Schulware
         {
             using var scope = serviceProvider.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<SchulwareDbContext>();
-            var client = scope.ServiceProvider.GetRequiredService<SchulwareApiClient>();
-            var logger = scope.ServiceProvider.GetRequiredService<ILogger<SchulwareSyncTask>>();
             var mainDb = scope.ServiceProvider.GetRequiredService<Schuly.Infrastructure.SchulyDbContext>();
+            var httpClientFactory = scope.ServiceProvider.GetRequiredService<IHttpClientFactory>();
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<SchulwareSyncTask>>();
 
-            var credentials = await db.Credentials.ToListAsync(cancellationToken);
+            var accounts = await db.Accounts
+                .Where(a => a.MobileAccessToken != null && a.SchoolUserId != null)
+                .ToListAsync(cancellationToken);
 
-            foreach (var credential in credentials)
+            logger.LogInformation("Syncing {Count} Schulware accounts", accounts.Count);
+
+            foreach (var account in accounts)
             {
                 var syncState = await db.SyncStates
-                    .FirstOrDefaultAsync(s => s.ApplicationUserId == credential.ApplicationUserId, cancellationToken);
+                    .FirstOrDefaultAsync(s => s.AccountId == account.Id, cancellationToken);
 
-                if (syncState == null)
+                if (syncState is null)
                 {
-                    syncState = new SyncState { ApplicationUserId = credential.ApplicationUserId };
+                    syncState = new SyncState { AccountId = account.Id };
                     db.SyncStates.Add(syncState);
                 }
 
                 try
                 {
-                    // TODO: Set bearer token on client from credential.EncryptedToken
-                    // TODO: Fetch grades, absences, exams from SchulwareAPI
-                    // TODO: Map and upsert into main Schuly DB
+                    if (account.MobileTokenExpiresAt.HasValue && account.MobileTokenExpiresAt < DateTime.UtcNow)
+                    {
+                        if (account.MobileRefreshToken is not null)
+                        {
+                            var refreshed = await TryRefreshToken(httpClientFactory, account, db, logger, cancellationToken);
+                            if (!refreshed)
+                            {
+                                syncState.LastSyncAt = DateTime.UtcNow;
+                                syncState.LastSyncStatus = "TokenExpired";
+                                syncState.LastSyncError = "Token expired and refresh failed. User needs to re-authenticate.";
+                                continue;
+                            }
+                        }
+                        else
+                        {
+                            syncState.LastSyncAt = DateTime.UtcNow;
+                            syncState.LastSyncStatus = "TokenExpired";
+                            syncState.LastSyncError = "Token expired. No refresh token available. User needs to re-authenticate.";
+                            continue;
+                        }
+                    }
+
+                    var client = CreateAuthenticatedClient(httpClientFactory, account);
+                    await SyncGrades(client, account, mainDb, logger, cancellationToken);
+                    await SyncAbsences(client, account, mainDb, logger, cancellationToken);
 
                     syncState.LastSyncAt = DateTime.UtcNow;
                     syncState.LastSyncStatus = "Success";
                     syncState.LastSyncError = null;
 
-                    logger.LogInformation("Synced data for user {UserId}", credential.ApplicationUserId);
+                    logger.LogInformation("Synced account {AccountId} ({Url})", account.Id, account.SchulnetzBaseUrl);
                 }
                 catch (Exception ex)
                 {
@@ -51,10 +82,183 @@ namespace Schuly.Plugin.Schulware
                     syncState.LastSyncStatus = "Failed";
                     syncState.LastSyncError = ex.Message;
 
-                    logger.LogError(ex, "Failed to sync data for user {UserId}", credential.ApplicationUserId);
+                    logger.LogError(ex, "Failed to sync account {AccountId}", account.Id);
                 }
 
                 await db.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        private static async Task<bool> TryRefreshToken(
+            IHttpClientFactory httpClientFactory, SchulwareAccount account,
+            SchulwareDbContext db, ILogger logger, CancellationToken ct)
+        {
+            try
+            {
+                using var httpClient = httpClientFactory.CreateClient("Schulware");
+                var tokenUrl = $"{account.SchulnetzBaseUrl}/token.php";
+
+                var content = new FormUrlEncodedContent(new[]
+                {
+                    new KeyValuePair<string, string>("grant_type", "refresh_token"),
+                    new KeyValuePair<string, string>("refresh_token", account.MobileRefreshToken!),
+                    new KeyValuePair<string, string>("client_id", "ppyybShnMerHdtBQ"),
+                });
+
+                var response = await httpClient.PostAsync(tokenUrl, content, ct);
+                if (!response.IsSuccessStatusCode)
+                {
+                    logger.LogWarning("Token refresh failed with {Status} for account {AccountId}", response.StatusCode, account.Id);
+                    return false;
+                }
+
+                var json = await response.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>(ct);
+                var accessToken = json.GetProperty("access_token").GetString();
+                var refreshToken = json.TryGetProperty("refresh_token", out var rt) ? rt.GetString() : account.MobileRefreshToken;
+
+                account.MobileAccessToken = accessToken;
+                account.MobileRefreshToken = refreshToken;
+                account.MobileTokenExpiresAt = DateTime.UtcNow.AddHours(1);
+                account.UpdatedAt = DateTime.UtcNow;
+                await db.SaveChangesAsync(ct);
+
+                logger.LogInformation("Refreshed token for account {AccountId}", account.Id);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Token refresh error for account {AccountId}", account.Id);
+                return false;
+            }
+        }
+
+        private static SchulwareApiClient CreateAuthenticatedClient(IHttpClientFactory httpClientFactory, SchulwareAccount account)
+        {
+            var httpClient = httpClientFactory.CreateClient("Schulware");
+            httpClient.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", account.MobileAccessToken);
+
+            var adapter = new HttpClientRequestAdapter(new AnonymousAuthenticationProvider(), httpClient: httpClient);
+            adapter.BaseUrl = account.SchulwareApiBaseUrl;
+            return new SchulwareApiClient(adapter);
+        }
+
+        private static async Task SyncGrades(
+            SchulwareApiClient client, SchulwareAccount account,
+            Schuly.Infrastructure.SchulyDbContext mainDb, ILogger logger, CancellationToken ct)
+        {
+            var grades = await client.Api.Mobile.Grades.GetAsync(cancellationToken: ct);
+            if (grades is null || grades.Count == 0) return;
+
+            var schoolUserId = account.SchoolUserId!.Value;
+            var synced = 0;
+
+            foreach (var grade in grades)
+            {
+                if (grade.Mark is null || grade.ExamId is null) continue;
+
+                var exam = await FindOrCreateExam(mainDb, grade, schoolUserId, ct);
+
+                var existing = await mainDb.Grades
+                    .FirstOrDefaultAsync(g => g.SchoolUserId == schoolUserId && g.ExamId == exam.Id, ct);
+
+                if (existing is null)
+                {
+                    mainDb.Grades.Add(new Grade
+                    {
+                        SchoolUserId = schoolUserId,
+                        ExamId = exam.Id,
+                        Score = (decimal)grade.Mark,
+                        Weighting = (decimal)(grade.Weight ?? 1),
+                    });
+                    synced++;
+                }
+                else if (existing.Score != (decimal)grade.Mark)
+                {
+                    existing.Score = (decimal)grade.Mark;
+                    existing.Weighting = (decimal)(grade.Weight ?? 1);
+                    synced++;
+                }
+            }
+
+            if (synced > 0)
+            {
+                await mainDb.SaveChangesAsync(ct);
+                logger.LogInformation("Synced {Count} grades for account {AccountId}", synced, account.Id);
+            }
+        }
+
+        private static async Task<Exam> FindOrCreateExam(
+            Schuly.Infrastructure.SchulyDbContext mainDb,
+            Client.Models.GradeDto grade, Guid schoolUserId, CancellationToken ct)
+        {
+            var examName = grade.Title ?? grade.Subject ?? $"Exam {grade.ExamId}";
+
+            var schoolUser = await mainDb.SchoolUsers
+                .Include(su => su.Classes)
+                .FirstOrDefaultAsync(su => su.Id == schoolUserId, ct);
+
+            var classId = schoolUser?.Classes.FirstOrDefault()?.Id ?? Guid.Empty;
+
+            var existing = await mainDb.Exams
+                .FirstOrDefaultAsync(e => e.Name == examName && e.ClassId == classId, ct);
+
+            if (existing is not null) return existing;
+
+            var exam = new Exam
+            {
+                Name = examName,
+                Type = ExamType.Classic,
+                ClassId = classId,
+            };
+            mainDb.Exams.Add(exam);
+            await mainDb.SaveChangesAsync(ct);
+            return exam;
+        }
+
+        private static async Task SyncAbsences(
+            SchulwareApiClient client, SchulwareAccount account,
+            Schuly.Infrastructure.SchulyDbContext mainDb, ILogger logger, CancellationToken ct)
+        {
+            var absences = await client.Api.Mobile.Absences.GetAsync(cancellationToken: ct);
+            if (absences is null || absences.Count == 0) return;
+
+            var schoolUserId = account.SchoolUserId!.Value;
+            var synced = 0;
+
+            foreach (var absence in absences)
+            {
+                if (absence.DateFrom is null || absence.DateTo is null) continue;
+
+                if (!DateTime.TryParse(absence.DateFrom, out var from) ||
+                    !DateTime.TryParse(absence.DateTo, out var to))
+                    continue;
+
+                from = DateTime.SpecifyKind(from, DateTimeKind.Utc);
+                to = DateTime.SpecifyKind(to, DateTimeKind.Utc);
+
+                var existing = await mainDb.Absences
+                    .FirstOrDefaultAsync(a => a.SchoolUserId == schoolUserId
+                        && a.From == from && a.Until == to, ct);
+
+                if (existing is null)
+                {
+                    mainDb.Absences.Add(new Absence
+                    {
+                        SchoolUserId = schoolUserId,
+                        From = from,
+                        Until = to,
+                        Reason = absence.Reason ?? "Imported from Schulnetz",
+                        Type = AbsenceType.Absence,
+                    });
+                    synced++;
+                }
+            }
+
+            if (synced > 0)
+            {
+                await mainDb.SaveChangesAsync(ct);
+                logger.LogInformation("Synced {Count} absences for account {AccountId}", synced, account.Id);
             }
         }
     }

--- a/src/Schuly.API/Extensions/PluginExtensions.cs
+++ b/src/Schuly.API/Extensions/PluginExtensions.cs
@@ -68,6 +68,23 @@ namespace Schuly.API.Extensions
         private static List<ISchulyPlugin> DiscoverPlugins(IConfiguration configuration)
         {
             var plugins = new List<ISchulyPlugin>();
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                try
+                {
+                    var pluginTypes = assembly.GetTypes()
+                        .Where(t => typeof(ISchulyPlugin).IsAssignableFrom(t) && t is { IsAbstract: false, IsInterface: false });
+
+                    foreach (var type in pluginTypes)
+                    {
+                        if (Activator.CreateInstance(type) is ISchulyPlugin plugin)
+                            plugins.Add(plugin);
+                    }
+                }
+                catch { }
+            }
+
             var pluginDir = configuration["Plugins:Directory"] ?? "plugins";
 
             if (!Path.IsPathRooted(pluginDir))

--- a/src/Schuly.API/Schuly.API.csproj
+++ b/src/Schuly.API/Schuly.API.csproj
@@ -10,6 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
+    <PackageReference Include="Mediator.SourceGenerator" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
@@ -27,6 +31,7 @@
     <ProjectReference Include="..\Schuly.Application\Schuly.Application.csproj" />
     <ProjectReference Include="..\Schuly.Infrastructure\Schuly.Infrastructure.csproj" />
     <ProjectReference Include="..\Schuly.Plugin.Abstractions\Schuly.Plugin.Abstractions.csproj" />
+    <ProjectReference Include="..\..\plugins\Schuly.Plugin.Schulware\Schuly.Plugin.Schulware.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Schuly.Application/Schuly.Application.csproj
+++ b/src/Schuly.Application/Schuly.Application.csproj
@@ -8,10 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
-    <PackageReference Include="Mediator.SourceGenerator" Version="3.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

One user can now connect multiple Schulnetz instances (different schools). Each account stores its own tokens, web session, and maps to a specific SchoolUser.

### Flow
1. `POST /accounts` — create account for a Schulnetz instance (e.g. schulnetz.bbbaden.ch)
2. `GET /accounts/{id}/auth/oauth/url` — get OAuth URL for that account
3. User authenticates via Microsoft SSO
4. `POST /accounts/{id}/auth/oauth/callback` — exchange code, stores mobile tokens + web session
5. Background sync pulls grades into main DB for the linked SchoolUser

### Data model
- `SchulwareAccount` — per user, per school: tokens, web session, SchoolUserId mapping
- `SyncState` — per account: last sync time/status
- Grades sync directly to `Schuly.Grade` table in main DB

## Test plan
- [x] Build passes (0 errors)
- [x] All 3 tests pass

resolve #220