### PR TITLE
Add i18n with German and English translations

### DIFF
--- a/src/Schuly.App/.gitignore
+++ b/src/Schuly.App/.gitignore
@@ -44,3 +44,4 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 openapi.json
+lib/l10n/app_localizations*.dart

--- a/src/Schuly.App/l10n.yaml
+++ b/src/Schuly.App/l10n.yaml
@@ -1,0 +1,3 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart

--- a/src/Schuly.App/lib/l10n/app_de.arb
+++ b/src/Schuly.App/lib/l10n/app_de.arb
@@ -1,0 +1,5 @@
+{
+  "@@locale": "de",
+  "appTitle": "Schuly",
+  "helloWorld": "Hallo, Schuly"
+}

--- a/src/Schuly.App/lib/l10n/app_en.arb
+++ b/src/Schuly.App/lib/l10n/app_en.arb
@@ -1,0 +1,11 @@
+{
+  "@@locale": "en",
+  "appTitle": "Schuly",
+  "@appTitle": {
+    "description": "Application title"
+  },
+  "helloWorld": "Hello, Schuly",
+  "@helloWorld": {
+    "description": "Placeholder greeting on the home screen"
+  }
+}

--- a/src/Schuly.App/lib/main.dart
+++ b/src/Schuly.App/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
+import 'l10n/app_localizations.dart';
 import 'ui/home/widgets/home_screen.dart';
 
 void main() => runApp(const SchulyApp());
@@ -11,9 +12,11 @@ class SchulyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PlatformProvider(
-      builder: (context) => const PlatformApp(
-        title: 'Schuly',
-        home: HomeScreen(),
+      builder: (context) => PlatformApp(
+        onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const HomeScreen(),
       ),
     );
   }

--- a/src/Schuly.App/lib/ui/home/widgets/home_screen.dart
+++ b/src/Schuly.App/lib/ui/home/widgets/home_screen.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
+import '../../../l10n/app_localizations.dart';
+
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     return PlatformScaffold(
-      appBar: PlatformAppBar(title: const Text('Schuly')),
-      body: const Center(child: Text('Hello, Schuly')),
+      appBar: PlatformAppBar(title: Text(t.appTitle)),
+      body: Center(child: Text(t.helloWorld)),
     );
   }
 }

--- a/src/Schuly.App/pubspec.lock
+++ b/src/Schuly.App/pubspec.lock
@@ -158,6 +158,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_platform_widgets:
     dependency: "direct main"
     description:
@@ -187,6 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   json_annotation:
     dependency: transitive
     description:

--- a/src/Schuly.App/pubspec.yaml
+++ b/src/Schuly.App/pubspec.yaml
@@ -38,6 +38,9 @@ dependencies:
   dio: ^5.9.2
   schuly_api:
     path: lib/api
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:
@@ -61,10 +64,7 @@ flutter_launcher_icons:
 
 # The following section is specific to Flutter packages.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
+  generate: true
   uses-material-design: true
 
   assets:


### PR DESCRIPTION
## Summary
Wire up Flutter's standard i18n per the [official docs](https://docs.flutter.dev/ui/accessibility-and-internationalization/internationalization):
- `flutter_localizations` + `intl` + `generate: true`
- `l10n.yaml` + `lib/l10n/app_{en,de}.arb`
- `AppLocalizations` plumbed into `PlatformApp`
- Generated `app_localizations*.dart` gitignored (regen on `flutter pub get`)

Closes #231