### PR TITLE
Add VS Code launch configs for dev/prod flavors

### DIFF
--- a/src/Schuly.App/.vscode/launch.json
+++ b/src/Schuly.App/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Schuly DEV (Debug)",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main.dart",
+      "args": ["--flavor", "dev"]
+    },
+    {
+      "name": "Schuly PROD (Debug)",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main.dart",
+      "args": ["--flavor", "prod"]
+    },
+    {
+      "name": "Schuly DEV (Profile)",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "profile",
+      "program": "lib/main.dart",
+      "args": ["--flavor", "dev"]
+    },
+    {
+      "name": "Schuly PROD (Release)",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "release",
+      "program": "lib/main.dart",
+      "args": ["--flavor", "prod"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Add `.vscode/launch.json` with Debug/Profile/Release configs for both `dev` and `prod` flavors. Without these, `flutter run` from VS Code fails because Gradle produces flavor-suffixed APKs.

Closes #233