### PR TITLE
Add debug AndroidManifest for VM service

### DIFF
--- a/src/Schuly.App/android/app/src/debug/AndroidManifest.xml
+++ b/src/Schuly.App/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- The INTERNET permission is required for development. Specifically,
+         the Flutter tool needs it to communicate with the running application
+         to allow setting breakpoints, to provide hot reload, etc.
+    -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+</manifest>


### PR DESCRIPTION
## Summary
Restore `android/app/src/debug/AndroidManifest.xml` so the Dart VM service can bind its socket in debug builds. The root `.gitignore` (from .NET) ignores any `[Dd]ebug/` folder, so the file is force-added.

Closes #235