### PR TITLE
Add adaptive bottom navigation with 5 tabs

### DIFF
--- a/src/Schuly.App/lib/l10n/app_de.arb
+++ b/src/Schuly.App/lib/l10n/app_de.arb
@@ -1,5 +1,9 @@
 {
   "@@locale": "de",
   "appTitle": "Schuly",
-  "helloWorld": "Hallo, Schuly"
+  "tabStart": "Start",
+  "tabAgenda": "Agenda",
+  "tabGrades": "Noten",
+  "tabAbsences": "Absenzen",
+  "tabAccount": "Konto"
 }

--- a/src/Schuly.App/lib/l10n/app_en.arb
+++ b/src/Schuly.App/lib/l10n/app_en.arb
@@ -4,8 +4,9 @@
   "@appTitle": {
     "description": "Application title"
   },
-  "helloWorld": "Hello, Schuly",
-  "@helloWorld": {
-    "description": "Placeholder greeting on the home screen"
-  }
+  "tabStart": "Start",
+  "tabAgenda": "Agenda",
+  "tabGrades": "Grades",
+  "tabAbsences": "Absences",
+  "tabAccount": "Account"
 }

--- a/src/Schuly.App/lib/main.dart
+++ b/src/Schuly.App/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
 import 'l10n/app_localizations.dart';
-import 'ui/home/widgets/home_screen.dart';
+import 'ui/core/ui/root_screen.dart';
 
 void main() => runApp(const SchulyApp());
 
@@ -16,7 +16,7 @@ class SchulyApp extends StatelessWidget {
         onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: const HomeScreen(),
+        home: const RootScreen(),
       ),
     );
   }

--- a/src/Schuly.App/lib/ui/absences/widgets/absences_screen.dart
+++ b/src/Schuly.App/lib/ui/absences/widgets/absences_screen.dart
@@ -3,15 +3,15 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
 import '../../../l10n/app_localizations.dart';
 
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+class AbsencesScreen extends StatelessWidget {
+  const AbsencesScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context)!;
     return PlatformScaffold(
-      appBar: PlatformAppBar(title: Text(t.tabStart)),
-      body: Center(child: Text(t.tabStart)),
+      appBar: PlatformAppBar(title: Text(t.tabAbsences)),
+      body: Center(child: Text(t.tabAbsences)),
     );
   }
 }

--- a/src/Schuly.App/lib/ui/account/widgets/account_screen.dart
+++ b/src/Schuly.App/lib/ui/account/widgets/account_screen.dart
@@ -3,15 +3,15 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
 import '../../../l10n/app_localizations.dart';
 
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+class AccountScreen extends StatelessWidget {
+  const AccountScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context)!;
     return PlatformScaffold(
-      appBar: PlatformAppBar(title: Text(t.tabStart)),
-      body: Center(child: Text(t.tabStart)),
+      appBar: PlatformAppBar(title: Text(t.tabAccount)),
+      body: Center(child: Text(t.tabAccount)),
     );
   }
 }

--- a/src/Schuly.App/lib/ui/agenda/widgets/agenda_screen.dart
+++ b/src/Schuly.App/lib/ui/agenda/widgets/agenda_screen.dart
@@ -3,15 +3,15 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
 import '../../../l10n/app_localizations.dart';
 
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+class AgendaScreen extends StatelessWidget {
+  const AgendaScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context)!;
     return PlatformScaffold(
-      appBar: PlatformAppBar(title: Text(t.tabStart)),
-      body: Center(child: Text(t.tabStart)),
+      appBar: PlatformAppBar(title: Text(t.tabAgenda)),
+      body: Center(child: Text(t.tabAgenda)),
     );
   }
 }

--- a/src/Schuly.App/lib/ui/core/ui/root_screen.dart
+++ b/src/Schuly.App/lib/ui/core/ui/root_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../absences/widgets/absences_screen.dart';
+import '../../account/widgets/account_screen.dart';
+import '../../agenda/widgets/agenda_screen.dart';
+import '../../grades/widgets/grades_screen.dart';
+import '../../home/widgets/home_screen.dart';
+
+class RootScreen extends StatelessWidget {
+  const RootScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
+    return PlatformTabScaffold(
+      items: [
+        BottomNavigationBarItem(icon: const Icon(Icons.home_outlined), label: t.tabStart),
+        BottomNavigationBarItem(icon: const Icon(Icons.calendar_today_outlined), label: t.tabAgenda),
+        BottomNavigationBarItem(icon: const Icon(Icons.grade_outlined), label: t.tabGrades),
+        BottomNavigationBarItem(icon: const Icon(Icons.event_busy_outlined), label: t.tabAbsences),
+        BottomNavigationBarItem(icon: const Icon(Icons.person_outline), label: t.tabAccount),
+      ],
+      bodyBuilder: (context, index) => switch (index) {
+        0 => const HomeScreen(),
+        1 => const AgendaScreen(),
+        2 => const GradesScreen(),
+        3 => const AbsencesScreen(),
+        _ => const AccountScreen(),
+      },
+    );
+  }
+}

--- a/src/Schuly.App/lib/ui/grades/widgets/grades_screen.dart
+++ b/src/Schuly.App/lib/ui/grades/widgets/grades_screen.dart
@@ -3,15 +3,15 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
 import '../../../l10n/app_localizations.dart';
 
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+class GradesScreen extends StatelessWidget {
+  const GradesScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context)!;
     return PlatformScaffold(
-      appBar: PlatformAppBar(title: Text(t.tabStart)),
-      body: Center(child: Text(t.tabStart)),
+      appBar: PlatformAppBar(title: Text(t.tabGrades)),
+      body: Center(child: Text(t.tabGrades)),
     );
   }
 }


### PR DESCRIPTION
## Summary
`PlatformTabScaffold` hosts five placeholder screens (Start/Agenda/Grades/Absences/Account). Renders Material `BottomNavigationBar` on Android, `CupertinoTabBar` on iOS — single widget tree, no per-platform branching. Tab labels via `AppLocalizations` (de + en).

Closes #237