### PR TITLE
Remove AppBar from tab screens

### DIFF
--- a/src/Schuly.App/lib/ui/absences/widgets/absences_screen.dart
+++ b/src/Schuly.App/lib/ui/absences/widgets/absences_screen.dart
@@ -10,7 +10,6 @@ class AbsencesScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context)!;
     return PlatformScaffold(
-      appBar: PlatformAppBar(title: Text(t.tabAbsences)),
       body: Center(child: Text(t.tabAbsences)),
     );
   }

--- a/src/Schuly.App/lib/ui/account/widgets/account_screen.dart
+++ b/src/Schuly.App/lib/ui/account/widgets/account_screen.dart
@@ -10,7 +10,6 @@ class AccountScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context)!;
     return PlatformScaffold(
-      appBar: PlatformAppBar(title: Text(t.tabAccount)),
       body: Center(child: Text(t.tabAccount)),
     );
   }

--- a/src/Schuly.App/lib/ui/agenda/widgets/agenda_screen.dart
+++ b/src/Schuly.App/lib/ui/agenda/widgets/agenda_screen.dart
@@ -10,7 +10,6 @@ class AgendaScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context)!;
     return PlatformScaffold(
-      appBar: PlatformAppBar(title: Text(t.tabAgenda)),
       body: Center(child: Text(t.tabAgenda)),
     );
   }

--- a/src/Schuly.App/lib/ui/grades/widgets/grades_screen.dart
+++ b/src/Schuly.App/lib/ui/grades/widgets/grades_screen.dart
@@ -10,7 +10,6 @@ class GradesScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context)!;
     return PlatformScaffold(
-      appBar: PlatformAppBar(title: Text(t.tabGrades)),
       body: Center(child: Text(t.tabGrades)),
     );
   }

--- a/src/Schuly.App/lib/ui/home/widgets/home_screen.dart
+++ b/src/Schuly.App/lib/ui/home/widgets/home_screen.dart
@@ -10,7 +10,6 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context)!;
     return PlatformScaffold(
-      appBar: PlatformAppBar(title: Text(t.tabStart)),
       body: Center(child: Text(t.tabStart)),
     );
   }


### PR DESCRIPTION
## Summary
Drop `PlatformAppBar` from each of the five tab screens — the bottom nav already labels each tab, so the top bar was redundant.

Closes #241