### PR TITLE
Sign-in button opens OIDC authorize URL

### DIFF
--- a/src/Schuly.App/lib/config/oidc_config.dart
+++ b/src/Schuly.App/lib/config/oidc_config.dart
@@ -1,0 +1,6 @@
+class OidcConfig {
+  static const authority = 'https://auth.gaggao.com';
+  static const clientId = 'fe2e0db0-69e3-48e3-845c-561f7a36d280';
+  static const scope = 'openid profile email groups picture';
+  static const redirectUri = 'com.schuly.app://callback';
+}

--- a/src/Schuly.App/lib/l10n/app_de.arb
+++ b/src/Schuly.App/lib/l10n/app_de.arb
@@ -5,5 +5,6 @@
   "tabAgenda": "Agenda",
   "tabGrades": "Noten",
   "tabAbsences": "Absenzen",
-  "tabAccount": "Konto"
+  "tabAccount": "Konto",
+  "signIn": "Anmelden"
 }

--- a/src/Schuly.App/lib/l10n/app_en.arb
+++ b/src/Schuly.App/lib/l10n/app_en.arb
@@ -8,5 +8,6 @@
   "tabAgenda": "Agenda",
   "tabGrades": "Grades",
   "tabAbsences": "Absences",
-  "tabAccount": "Account"
+  "tabAccount": "Account",
+  "signIn": "Sign in"
 }

--- a/src/Schuly.App/lib/ui/account/widgets/account_screen.dart
+++ b/src/Schuly.App/lib/ui/account/widgets/account_screen.dart
@@ -1,16 +1,39 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
+import 'package:url_launcher/url_launcher.dart';
 
+import '../../../config/oidc_config.dart';
 import '../../../l10n/app_localizations.dart';
 
 class AccountScreen extends StatelessWidget {
   const AccountScreen({super.key});
 
+  Future<void> _openAuthPage() async {
+    final url = Uri.parse(OidcConfig.authority).replace(
+      path: '/authorize',
+      queryParameters: {
+        'client_id': OidcConfig.clientId,
+        'response_type': 'code',
+        'scope': OidcConfig.scope,
+        'redirect_uri': OidcConfig.redirectUri,
+        'state': 'test',
+      },
+    );
+    await launchUrl(url, mode: LaunchMode.externalApplication);
+  }
+
   @override
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context)!;
     return PlatformScaffold(
-      body: Center(child: Text(t.tabAccount)),
+      body: SafeArea(
+        child: Center(
+          child: PlatformElevatedButton(
+            onPressed: _openAuthPage,
+            child: Text(t.signIn),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/src/Schuly.App/pubspec.lock
+++ b/src/Schuly.App/pubspec.lock
@@ -176,6 +176,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   http_parser:
     dependency: transitive
     description:
@@ -304,6 +309,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   posix:
     dependency: transitive
     description:
@@ -388,6 +401,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.29"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:

--- a/src/Schuly.App/pubspec.yaml
+++ b/src/Schuly.App/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: ^0.20.2
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
Add a `Sign in` button on the Account screen that opens Pocket ID's authorize URL in the system browser via `url_launcher`. Just to verify passkeys render — callback handling and token exchange come in a follow-up.

`OidcConfig` lives at `lib/config/oidc_config.dart`.

Closes #245