### PR TITLE
Open auth page in in-app browser

### DIFF
--- a/src/Schuly.App/lib/ui/account/widgets/account_screen.dart
+++ b/src/Schuly.App/lib/ui/account/widgets/account_screen.dart
@@ -19,7 +19,7 @@ class AccountScreen extends StatelessWidget {
         'state': 'test',
       },
     );
-    await launchUrl(url, mode: LaunchMode.externalApplication);
+    await launchUrl(url, mode: LaunchMode.inAppBrowserView);
   }
 
   @override


### PR DESCRIPTION
## Summary
Switch `launchUrl` mode from `externalApplication` to `inAppBrowserView` so Pocket ID opens in Chrome Custom Tabs / SFSafariViewController. Both still support passkeys.

Closes #247