### PR TITLE
Timetable, Absences, Account tabs + OdaOrg provider

### DIFF
--- a/lib/api/.openapi-generator/FILES
+++ b/lib/api/.openapi-generator/FILES
@@ -17,6 +17,7 @@ doc/AuthApi.md
 doc/ClassApi.md
 doc/ClassDto.md
 doc/ConnectAccountRequest.md
+doc/ConnectOdaOrgRequest.md
 doc/CreateAbsenceCommand.md
 doc/CreateAgendaEntryCommand.md
 doc/CreateApplicationUserCommand.md
@@ -96,6 +97,7 @@ lib/src/model/app_dto.dart
 lib/src/model/application_user_dto.dart
 lib/src/model/class_dto.dart
 lib/src/model/connect_account_request.dart
+lib/src/model/connect_oda_org_request.dart
 lib/src/model/create_absence_command.dart
 lib/src/model/create_agenda_entry_command.dart
 lib/src/model/create_application_user_command.dart
@@ -133,7 +135,3 @@ lib/src/model/user_class_dto.dart
 lib/src/model/user_state.dart
 lib/src/serializers.dart
 pubspec.yaml
-test/semester_report_dto_test.dart
-test/semester_reports_api_test.dart
-test/semester_subject_grade_dto_test.dart
-test/student_document_dto_test.dart

--- a/lib/api/README.md
+++ b/lib/api/README.md
@@ -69,6 +69,9 @@ Class | Method | HTTP request | Description
 [*AbsencesApi*](doc/AbsencesApi.md) | [**apiAbsencesPost**](doc/AbsencesApi.md#apiabsencespost) | **POST** /api/Absences | 
 [*AbsencesApi*](doc/AbsencesApi.md) | [**apiAbsencesPut**](doc/AbsencesApi.md#apiabsencesput) | **PUT** /api/Absences | 
 [*AbsencesApi*](doc/AbsencesApi.md) | [**apiAbsencesSearchGet**](doc/AbsencesApi.md#apiabsencessearchget) | **GET** /api/Absences/search | 
+[*AccountsApi*](doc/AccountsApi.md) | [**apiPluginsOdaorgAccountsAccountIdDelete**](doc/AccountsApi.md#apipluginsodaorgaccountsaccountiddelete) | **DELETE** /api/plugins/odaorg/accounts/{accountId} | 
+[*AccountsApi*](doc/AccountsApi.md) | [**apiPluginsOdaorgAccountsGet**](doc/AccountsApi.md#apipluginsodaorgaccountsget) | **GET** /api/plugins/odaorg/accounts | 
+[*AccountsApi*](doc/AccountsApi.md) | [**apiPluginsOdaorgAccountsPost**](doc/AccountsApi.md#apipluginsodaorgaccountspost) | **POST** /api/plugins/odaorg/accounts | 
 [*AccountsApi*](doc/AccountsApi.md) | [**apiPluginsSchulwareAccountsAccountIdDelete**](doc/AccountsApi.md#apipluginsschulwareaccountsaccountiddelete) | **DELETE** /api/plugins/schulware/accounts/{accountId} | 
 [*AccountsApi*](doc/AccountsApi.md) | [**apiPluginsSchulwareAccountsGet**](doc/AccountsApi.md#apipluginsschulwareaccountsget) | **GET** /api/plugins/schulware/accounts | 
 [*AccountsApi*](doc/AccountsApi.md) | [**apiPluginsSchulwareAccountsPost**](doc/AccountsApi.md#apipluginsschulwareaccountspost) | **POST** /api/plugins/schulware/accounts | 
@@ -113,10 +116,13 @@ Class | Method | HTTP request | Description
 [*SchoolsApi*](doc/SchoolsApi.md) | [**apiSchoolsPost**](doc/SchoolsApi.md#apischoolspost) | **POST** /api/Schools | 
 [*SchoolsApi*](doc/SchoolsApi.md) | [**apiSchoolsPut**](doc/SchoolsApi.md#apischoolsput) | **PUT** /api/Schools | 
 [*SemesterReportsApi*](doc/SemesterReportsApi.md) | [**apiSemesterReportsGet**](doc/SemesterReportsApi.md#apisemesterreportsget) | **GET** /api/SemesterReports | 
+[*StatusApi*](doc/StatusApi.md) | [**apiPluginsOdaorgStatusGet**](doc/StatusApi.md#apipluginsodaorgstatusget) | **GET** /api/plugins/odaorg/status | 
 [*StatusApi*](doc/StatusApi.md) | [**apiPluginsSchulwareStatusGet**](doc/StatusApi.md#apipluginsschulwarestatusget) | **GET** /api/plugins/schulware/status | 
 [*StudentDocumentsApi*](doc/StudentDocumentsApi.md) | [**apiDocumentsDocumentIdGet**](doc/StudentDocumentsApi.md#apidocumentsdocumentidget) | **GET** /api/documents/{documentId} | 
 [*StudentDocumentsApi*](doc/StudentDocumentsApi.md) | [**apiDocumentsGet**](doc/StudentDocumentsApi.md#apidocumentsget) | **GET** /api/documents | 
 [*StudentDocumentsApi*](doc/StudentDocumentsApi.md) | [**apiStudentsSchoolUserIdDocumentsPost**](doc/StudentDocumentsApi.md#apistudentsschooluseriddocumentspost) | **POST** /api/students/{schoolUserId}/documents | 
+[*SyncApi*](doc/SyncApi.md) | [**apiPluginsOdaorgAccountsAccountIdSyncGet**](doc/SyncApi.md#apipluginsodaorgaccountsaccountidsyncget) | **GET** /api/plugins/odaorg/accounts/{accountId}/sync | 
+[*SyncApi*](doc/SyncApi.md) | [**apiPluginsOdaorgAccountsAccountIdSyncPost**](doc/SyncApi.md#apipluginsodaorgaccountsaccountidsyncpost) | **POST** /api/plugins/odaorg/accounts/{accountId}/sync | 
 [*SyncApi*](doc/SyncApi.md) | [**apiPluginsSchulwareAccountsAccountIdSyncGet**](doc/SyncApi.md#apipluginsschulwareaccountsaccountidsyncget) | **GET** /api/plugins/schulware/accounts/{accountId}/sync | 
 [*SyncApi*](doc/SyncApi.md) | [**apiPluginsSchulwareAccountsAccountIdSyncPost**](doc/SyncApi.md#apipluginsschulwareaccountsaccountidsyncpost) | **POST** /api/plugins/schulware/accounts/{accountId}/sync | 
 [*TeachersApi*](doc/TeachersApi.md) | [**apiTeachersGet**](doc/TeachersApi.md#apiteachersget) | **GET** /api/Teachers | 
@@ -137,6 +143,7 @@ Class | Method | HTTP request | Description
  - [ApplicationUserDto](doc/ApplicationUserDto.md)
  - [ClassDto](doc/ClassDto.md)
  - [ConnectAccountRequest](doc/ConnectAccountRequest.md)
+ - [ConnectOdaOrgRequest](doc/ConnectOdaOrgRequest.md)
  - [CreateAbsenceCommand](doc/CreateAbsenceCommand.md)
  - [CreateAgendaEntryCommand](doc/CreateAgendaEntryCommand.md)
  - [CreateApplicationUserCommand](doc/CreateApplicationUserCommand.md)

--- a/lib/api/doc/AccountsApi.md
+++ b/lib/api/doc/AccountsApi.md
@@ -9,10 +9,135 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**apiPluginsOdaorgAccountsAccountIdDelete**](AccountsApi.md#apipluginsodaorgaccountsaccountiddelete) | **DELETE** /api/plugins/odaorg/accounts/{accountId} | 
+[**apiPluginsOdaorgAccountsGet**](AccountsApi.md#apipluginsodaorgaccountsget) | **GET** /api/plugins/odaorg/accounts | 
+[**apiPluginsOdaorgAccountsPost**](AccountsApi.md#apipluginsodaorgaccountspost) | **POST** /api/plugins/odaorg/accounts | 
 [**apiPluginsSchulwareAccountsAccountIdDelete**](AccountsApi.md#apipluginsschulwareaccountsaccountiddelete) | **DELETE** /api/plugins/schulware/accounts/{accountId} | 
 [**apiPluginsSchulwareAccountsGet**](AccountsApi.md#apipluginsschulwareaccountsget) | **GET** /api/plugins/schulware/accounts | 
 [**apiPluginsSchulwareAccountsPost**](AccountsApi.md#apipluginsschulwareaccountspost) | **POST** /api/plugins/schulware/accounts | 
 
+
+# **apiPluginsOdaorgAccountsAccountIdDelete**
+> apiPluginsOdaorgAccountsAccountIdDelete(accountId)
+
+
+
+### Example
+```dart
+import 'package:schuly_api/api.dart';
+// TODO Configure OAuth2 access token for authorization: OAuth2
+//defaultApiClient.getAuthentication<OAuth>('OAuth2').accessToken = 'YOUR_ACCESS_TOKEN';
+
+final api = SchulyApi().getAccountsApi();
+final String accountId = 38400000-8cf0-11bd-b23e-10b96e4ef00d; // String | 
+
+try {
+    api.apiPluginsOdaorgAccountsAccountIdDelete(accountId);
+} catch on DioException (e) {
+    print('Exception when calling AccountsApi->apiPluginsOdaorgAccountsAccountIdDelete: $e\n');
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **accountId** | **String**|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+[OAuth2](../README.md#OAuth2)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **apiPluginsOdaorgAccountsGet**
+> apiPluginsOdaorgAccountsGet()
+
+
+
+### Example
+```dart
+import 'package:schuly_api/api.dart';
+// TODO Configure OAuth2 access token for authorization: OAuth2
+//defaultApiClient.getAuthentication<OAuth>('OAuth2').accessToken = 'YOUR_ACCESS_TOKEN';
+
+final api = SchulyApi().getAccountsApi();
+
+try {
+    api.apiPluginsOdaorgAccountsGet();
+} catch on DioException (e) {
+    print('Exception when calling AccountsApi->apiPluginsOdaorgAccountsGet: $e\n');
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+[OAuth2](../README.md#OAuth2)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **apiPluginsOdaorgAccountsPost**
+> apiPluginsOdaorgAccountsPost(connectOdaOrgRequest)
+
+
+
+### Example
+```dart
+import 'package:schuly_api/api.dart';
+// TODO Configure OAuth2 access token for authorization: OAuth2
+//defaultApiClient.getAuthentication<OAuth>('OAuth2').accessToken = 'YOUR_ACCESS_TOKEN';
+
+final api = SchulyApi().getAccountsApi();
+final ConnectOdaOrgRequest connectOdaOrgRequest = ; // ConnectOdaOrgRequest | 
+
+try {
+    api.apiPluginsOdaorgAccountsPost(connectOdaOrgRequest);
+} catch on DioException (e) {
+    print('Exception when calling AccountsApi->apiPluginsOdaorgAccountsPost: $e\n');
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **connectOdaOrgRequest** | [**ConnectOdaOrgRequest**](ConnectOdaOrgRequest.md)|  | [optional] 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+[OAuth2](../README.md#OAuth2)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json, text/json, application/*+json
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **apiPluginsSchulwareAccountsAccountIdDelete**
 > apiPluginsSchulwareAccountsAccountIdDelete(accountId)

--- a/lib/api/doc/ConnectOdaOrgRequest.md
+++ b/lib/api/doc/ConnectOdaOrgRequest.md
@@ -1,4 +1,4 @@
-# schuly_api.model.MySchoolDto
+# schuly_api.model.ConnectOdaOrgRequest
 
 ## Load the model package
 ```dart
@@ -8,12 +8,10 @@ import 'package:schuly_api/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **String** |  | [optional] 
-**name** | **String** |  | 
-**email** | **String** |  | 
-**fullName** | **String** |  | 
-**logoUrl** | **String** |  | [optional] 
-**profilePictureUrl** | **String** |  | [optional] 
+**username** | **String** |  | [optional] 
+**password** | **String** |  | [optional] 
+**baseUrl** | **String** |  | [optional] 
+**displayName** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/lib/api/doc/CreateSchoolCommand.md
+++ b/lib/api/doc/CreateSchoolCommand.md
@@ -18,6 +18,7 @@ Name | Type | Description | Notes
 **state** | **String** |  | [optional] 
 **zip** | **String** |  | [optional] 
 **country** | **String** |  | [optional] 
+**logoUrl** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/lib/api/doc/CreateSchoolUserCommand.md
+++ b/lib/api/doc/CreateSchoolUserCommand.md
@@ -21,6 +21,7 @@ Name | Type | Description | Notes
 **birthday** | [**Date**](Date.md) |  | [optional] 
 **entryDate** | [**Date**](Date.md) |  | [optional] 
 **role** | [**Roles**](Roles.md) |  | [optional] 
+**profilePictureUrl** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/lib/api/doc/SchoolDto.md
+++ b/lib/api/doc/SchoolDto.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **state** | **String** |  | [optional] 
 **zip** | **String** |  | [optional] 
 **country** | **String** |  | [optional] 
+**logoUrl** | **String** |  | [optional] 
 **createdAt** | [**DateTime**](DateTime.md) |  | [optional] 
 **updatedAt** | [**DateTime**](DateTime.md) |  | [optional] 
 

--- a/lib/api/doc/SchoolUserDto.md
+++ b/lib/api/doc/SchoolUserDto.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **email** | **String** |  | 
 **privateEmail** | **String** |  | [optional] 
 **phoneNumber** | **String** |  | [optional] 
+**profilePictureUrl** | **String** |  | [optional] 
 **street** | **String** |  | [optional] 
 **city** | **String** |  | [optional] 
 **zip** | **String** |  | [optional] 

--- a/lib/api/doc/StatusApi.md
+++ b/lib/api/doc/StatusApi.md
@@ -9,8 +9,47 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**apiPluginsOdaorgStatusGet**](StatusApi.md#apipluginsodaorgstatusget) | **GET** /api/plugins/odaorg/status | 
 [**apiPluginsSchulwareStatusGet**](StatusApi.md#apipluginsschulwarestatusget) | **GET** /api/plugins/schulware/status | 
 
+
+# **apiPluginsOdaorgStatusGet**
+> apiPluginsOdaorgStatusGet()
+
+
+
+### Example
+```dart
+import 'package:schuly_api/api.dart';
+// TODO Configure OAuth2 access token for authorization: OAuth2
+//defaultApiClient.getAuthentication<OAuth>('OAuth2').accessToken = 'YOUR_ACCESS_TOKEN';
+
+final api = SchulyApi().getStatusApi();
+
+try {
+    api.apiPluginsOdaorgStatusGet();
+} catch on DioException (e) {
+    print('Exception when calling StatusApi->apiPluginsOdaorgStatusGet: $e\n');
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+[OAuth2](../README.md#OAuth2)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **apiPluginsSchulwareStatusGet**
 > apiPluginsSchulwareStatusGet()

--- a/lib/api/doc/SyncApi.md
+++ b/lib/api/doc/SyncApi.md
@@ -9,9 +9,95 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**apiPluginsOdaorgAccountsAccountIdSyncGet**](SyncApi.md#apipluginsodaorgaccountsaccountidsyncget) | **GET** /api/plugins/odaorg/accounts/{accountId}/sync | 
+[**apiPluginsOdaorgAccountsAccountIdSyncPost**](SyncApi.md#apipluginsodaorgaccountsaccountidsyncpost) | **POST** /api/plugins/odaorg/accounts/{accountId}/sync | 
 [**apiPluginsSchulwareAccountsAccountIdSyncGet**](SyncApi.md#apipluginsschulwareaccountsaccountidsyncget) | **GET** /api/plugins/schulware/accounts/{accountId}/sync | 
 [**apiPluginsSchulwareAccountsAccountIdSyncPost**](SyncApi.md#apipluginsschulwareaccountsaccountidsyncpost) | **POST** /api/plugins/schulware/accounts/{accountId}/sync | 
 
+
+# **apiPluginsOdaorgAccountsAccountIdSyncGet**
+> apiPluginsOdaorgAccountsAccountIdSyncGet(accountId)
+
+
+
+### Example
+```dart
+import 'package:schuly_api/api.dart';
+// TODO Configure OAuth2 access token for authorization: OAuth2
+//defaultApiClient.getAuthentication<OAuth>('OAuth2').accessToken = 'YOUR_ACCESS_TOKEN';
+
+final api = SchulyApi().getSyncApi();
+final String accountId = 38400000-8cf0-11bd-b23e-10b96e4ef00d; // String | 
+
+try {
+    api.apiPluginsOdaorgAccountsAccountIdSyncGet(accountId);
+} catch on DioException (e) {
+    print('Exception when calling SyncApi->apiPluginsOdaorgAccountsAccountIdSyncGet: $e\n');
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **accountId** | **String**|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+[OAuth2](../README.md#OAuth2)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **apiPluginsOdaorgAccountsAccountIdSyncPost**
+> apiPluginsOdaorgAccountsAccountIdSyncPost(accountId)
+
+
+
+### Example
+```dart
+import 'package:schuly_api/api.dart';
+// TODO Configure OAuth2 access token for authorization: OAuth2
+//defaultApiClient.getAuthentication<OAuth>('OAuth2').accessToken = 'YOUR_ACCESS_TOKEN';
+
+final api = SchulyApi().getSyncApi();
+final String accountId = 38400000-8cf0-11bd-b23e-10b96e4ef00d; // String | 
+
+try {
+    api.apiPluginsOdaorgAccountsAccountIdSyncPost(accountId);
+} catch on DioException (e) {
+    print('Exception when calling SyncApi->apiPluginsOdaorgAccountsAccountIdSyncPost: $e\n');
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **accountId** | **String**|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+[OAuth2](../README.md#OAuth2)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **apiPluginsSchulwareAccountsAccountIdSyncGet**
 > apiPluginsSchulwareAccountsAccountIdSyncGet(accountId)

--- a/lib/api/doc/UpdateSchoolCommand.md
+++ b/lib/api/doc/UpdateSchoolCommand.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **state** | **String** |  | [optional] 
 **zip** | **String** |  | [optional] 
 **country** | **String** |  | [optional] 
+**logoUrl** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/lib/api/doc/UpdateSchoolUserCommand.md
+++ b/lib/api/doc/UpdateSchoolUserCommand.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **zip** | **String** |  | [optional] 
 **leaveDate** | [**Date**](Date.md) |  | [optional] 
 **state** | [**UserState**](UserState.md) |  | [optional] 
+**profilePictureUrl** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/lib/api/lib/schuly_api.dart
+++ b/lib/api/lib/schuly_api.dart
@@ -37,6 +37,7 @@ export 'package:schuly_api/src/model/app_dto.dart';
 export 'package:schuly_api/src/model/application_user_dto.dart';
 export 'package:schuly_api/src/model/class_dto.dart';
 export 'package:schuly_api/src/model/connect_account_request.dart';
+export 'package:schuly_api/src/model/connect_oda_org_request.dart';
 export 'package:schuly_api/src/model/create_absence_command.dart';
 export 'package:schuly_api/src/model/create_agenda_entry_command.dart';
 export 'package:schuly_api/src/model/create_application_user_command.dart';

--- a/lib/api/lib/src/api/accounts_api.dart
+++ b/lib/api/lib/src/api/accounts_api.dart
@@ -10,6 +10,7 @@ import 'package:dio/dio.dart';
 
 import 'package:schuly_api/src/api_util.dart';
 import 'package:schuly_api/src/model/connect_account_request.dart';
+import 'package:schuly_api/src/model/connect_oda_org_request.dart';
 
 class AccountsApi {
 
@@ -18,6 +19,180 @@ class AccountsApi {
   final Serializers _serializers;
 
   const AccountsApi(this._dio, this._serializers);
+
+  /// apiPluginsOdaorgAccountsAccountIdDelete
+  /// 
+  ///
+  /// Parameters:
+  /// * [accountId] 
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future]
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<void>> apiPluginsOdaorgAccountsAccountIdDelete({ 
+    required String accountId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/plugins/odaorg/accounts/{accountId}'.replaceAll('{' r'accountId' '}', encodeQueryParameter(_serializers, accountId, const FullType(String)).toString());
+    final _options = Options(
+      method: r'DELETE',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {
+            'type': 'oauth2',
+            'name': 'OAuth2',
+          },
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    return _response;
+  }
+
+  /// apiPluginsOdaorgAccountsGet
+  /// 
+  ///
+  /// Parameters:
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future]
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<void>> apiPluginsOdaorgAccountsGet({ 
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/plugins/odaorg/accounts';
+    final _options = Options(
+      method: r'GET',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {
+            'type': 'oauth2',
+            'name': 'OAuth2',
+          },
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    return _response;
+  }
+
+  /// apiPluginsOdaorgAccountsPost
+  /// 
+  ///
+  /// Parameters:
+  /// * [connectOdaOrgRequest] 
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future]
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<void>> apiPluginsOdaorgAccountsPost({ 
+    ConnectOdaOrgRequest? connectOdaOrgRequest,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/plugins/odaorg/accounts';
+    final _options = Options(
+      method: r'POST',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {
+            'type': 'oauth2',
+            'name': 'OAuth2',
+          },
+        ],
+        ...?extra,
+      },
+      contentType: 'application/json',
+      validateStatus: validateStatus,
+    );
+
+    dynamic _bodyData;
+
+    try {
+      const _type = FullType(ConnectOdaOrgRequest);
+      _bodyData = connectOdaOrgRequest == null ? null : _serializers.serialize(connectOdaOrgRequest, specifiedType: _type);
+
+    } catch(error, stackTrace) {
+      throw DioException(
+         requestOptions: _options.compose(
+          _dio.options,
+          _path,
+        ),
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    final _response = await _dio.request<Object>(
+      _path,
+      data: _bodyData,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    return _response;
+  }
 
   /// apiPluginsSchulwareAccountsAccountIdDelete
   /// 

--- a/lib/api/lib/src/api/status_api.dart
+++ b/lib/api/lib/src/api/status_api.dart
@@ -17,6 +17,56 @@ class StatusApi {
 
   const StatusApi(this._dio, this._serializers);
 
+  /// apiPluginsOdaorgStatusGet
+  /// 
+  ///
+  /// Parameters:
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future]
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<void>> apiPluginsOdaorgStatusGet({ 
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/plugins/odaorg/status';
+    final _options = Options(
+      method: r'GET',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {
+            'type': 'oauth2',
+            'name': 'OAuth2',
+          },
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    return _response;
+  }
+
   /// apiPluginsSchulwareStatusGet
   /// 
   ///

--- a/lib/api/lib/src/api/sync_api.dart
+++ b/lib/api/lib/src/api/sync_api.dart
@@ -18,6 +18,110 @@ class SyncApi {
 
   const SyncApi(this._dio, this._serializers);
 
+  /// apiPluginsOdaorgAccountsAccountIdSyncGet
+  /// 
+  ///
+  /// Parameters:
+  /// * [accountId] 
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future]
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<void>> apiPluginsOdaorgAccountsAccountIdSyncGet({ 
+    required String accountId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/plugins/odaorg/accounts/{accountId}/sync'.replaceAll('{' r'accountId' '}', encodeQueryParameter(_serializers, accountId, const FullType(String)).toString());
+    final _options = Options(
+      method: r'GET',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {
+            'type': 'oauth2',
+            'name': 'OAuth2',
+          },
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    return _response;
+  }
+
+  /// apiPluginsOdaorgAccountsAccountIdSyncPost
+  /// 
+  ///
+  /// Parameters:
+  /// * [accountId] 
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future]
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<void>> apiPluginsOdaorgAccountsAccountIdSyncPost({ 
+    required String accountId,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/plugins/odaorg/accounts/{accountId}/sync'.replaceAll('{' r'accountId' '}', encodeQueryParameter(_serializers, accountId, const FullType(String)).toString());
+    final _options = Options(
+      method: r'POST',
+      headers: <String, dynamic>{
+        ...?headers,
+      },
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {
+            'type': 'oauth2',
+            'name': 'OAuth2',
+          },
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    return _response;
+  }
+
   /// apiPluginsSchulwareAccountsAccountIdSyncGet
   /// 
   ///

--- a/lib/api/lib/src/model/connect_oda_org_request.dart
+++ b/lib/api/lib/src/model/connect_oda_org_request.dart
@@ -6,93 +6,77 @@
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 
-part 'my_school_dto.g.dart';
+part 'connect_oda_org_request.g.dart';
 
-/// MySchoolDto
+/// ConnectOdaOrgRequest
 ///
 /// Properties:
-/// * [id] 
-/// * [name] 
-/// * [email] 
-/// * [fullName] 
-/// * [logoUrl] 
-/// * [profilePictureUrl] 
+/// * [username] 
+/// * [password] 
+/// * [baseUrl] 
+/// * [displayName] 
 @BuiltValue()
-abstract class MySchoolDto implements Built<MySchoolDto, MySchoolDtoBuilder> {
-  @BuiltValueField(wireName: r'id')
-  String? get id;
+abstract class ConnectOdaOrgRequest implements Built<ConnectOdaOrgRequest, ConnectOdaOrgRequestBuilder> {
+  @BuiltValueField(wireName: r'username')
+  String? get username;
 
-  @BuiltValueField(wireName: r'name')
-  String? get name;
+  @BuiltValueField(wireName: r'password')
+  String? get password;
 
-  @BuiltValueField(wireName: r'email')
-  String? get email;
+  @BuiltValueField(wireName: r'baseUrl')
+  String? get baseUrl;
 
-  @BuiltValueField(wireName: r'fullName')
-  String? get fullName;
+  @BuiltValueField(wireName: r'displayName')
+  String? get displayName;
 
-  @BuiltValueField(wireName: r'logoUrl')
-  String? get logoUrl;
+  ConnectOdaOrgRequest._();
 
-  @BuiltValueField(wireName: r'profilePictureUrl')
-  String? get profilePictureUrl;
-
-  MySchoolDto._();
-
-  factory MySchoolDto([void updates(MySchoolDtoBuilder b)]) = _$MySchoolDto;
+  factory ConnectOdaOrgRequest([void updates(ConnectOdaOrgRequestBuilder b)]) = _$ConnectOdaOrgRequest;
 
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults(MySchoolDtoBuilder b) => b;
+  static void _defaults(ConnectOdaOrgRequestBuilder b) => b;
 
   @BuiltValueSerializer(custom: true)
-  static Serializer<MySchoolDto> get serializer => _$MySchoolDtoSerializer();
+  static Serializer<ConnectOdaOrgRequest> get serializer => _$ConnectOdaOrgRequestSerializer();
 }
 
-class _$MySchoolDtoSerializer implements PrimitiveSerializer<MySchoolDto> {
+class _$ConnectOdaOrgRequestSerializer implements PrimitiveSerializer<ConnectOdaOrgRequest> {
   @override
-  final Iterable<Type> types = const [MySchoolDto, _$MySchoolDto];
+  final Iterable<Type> types = const [ConnectOdaOrgRequest, _$ConnectOdaOrgRequest];
 
   @override
-  final String wireName = r'MySchoolDto';
+  final String wireName = r'ConnectOdaOrgRequest';
 
   Iterable<Object?> _serializeProperties(
     Serializers serializers,
-    MySchoolDto object, {
+    ConnectOdaOrgRequest object, {
     FullType specifiedType = FullType.unspecified,
   }) sync* {
-    if (object.id != null) {
-      yield r'id';
+    if (object.username != null) {
+      yield r'username';
       yield serializers.serialize(
-        object.id,
-        specifiedType: const FullType(String),
-      );
-    }
-    yield r'name';
-    yield object.name == null ? null : serializers.serialize(
-      object.name,
-      specifiedType: const FullType.nullable(String),
-    );
-    yield r'email';
-    yield object.email == null ? null : serializers.serialize(
-      object.email,
-      specifiedType: const FullType.nullable(String),
-    );
-    yield r'fullName';
-    yield object.fullName == null ? null : serializers.serialize(
-      object.fullName,
-      specifiedType: const FullType.nullable(String),
-    );
-    if (object.logoUrl != null) {
-      yield r'logoUrl';
-      yield serializers.serialize(
-        object.logoUrl,
+        object.username,
         specifiedType: const FullType.nullable(String),
       );
     }
-    if (object.profilePictureUrl != null) {
-      yield r'profilePictureUrl';
+    if (object.password != null) {
+      yield r'password';
       yield serializers.serialize(
-        object.profilePictureUrl,
+        object.password,
+        specifiedType: const FullType.nullable(String),
+      );
+    }
+    if (object.baseUrl != null) {
+      yield r'baseUrl';
+      yield serializers.serialize(
+        object.baseUrl,
+        specifiedType: const FullType.nullable(String),
+      );
+    }
+    if (object.displayName != null) {
+      yield r'displayName';
+      yield serializers.serialize(
+        object.displayName,
         specifiedType: const FullType.nullable(String),
       );
     }
@@ -101,7 +85,7 @@ class _$MySchoolDtoSerializer implements PrimitiveSerializer<MySchoolDto> {
   @override
   Object serialize(
     Serializers serializers,
-    MySchoolDto object, {
+    ConnectOdaOrgRequest object, {
     FullType specifiedType = FullType.unspecified,
   }) {
     return _serializeProperties(serializers, object, specifiedType: specifiedType).toList();
@@ -112,59 +96,44 @@ class _$MySchoolDtoSerializer implements PrimitiveSerializer<MySchoolDto> {
     Object serialized, {
     FullType specifiedType = FullType.unspecified,
     required List<Object?> serializedList,
-    required MySchoolDtoBuilder result,
+    required ConnectOdaOrgRequestBuilder result,
     required List<Object?> unhandled,
   }) {
     for (var i = 0; i < serializedList.length; i += 2) {
       final key = serializedList[i] as String;
       final value = serializedList[i + 1];
       switch (key) {
-        case r'id':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType(String),
-          ) as String;
-          result.id = valueDes;
-          break;
-        case r'name':
+        case r'username':
           final valueDes = serializers.deserialize(
             value,
             specifiedType: const FullType.nullable(String),
           ) as String?;
           if (valueDes == null) continue;
-          result.name = valueDes;
+          result.username = valueDes;
           break;
-        case r'email':
+        case r'password':
           final valueDes = serializers.deserialize(
             value,
             specifiedType: const FullType.nullable(String),
           ) as String?;
           if (valueDes == null) continue;
-          result.email = valueDes;
+          result.password = valueDes;
           break;
-        case r'fullName':
+        case r'baseUrl':
           final valueDes = serializers.deserialize(
             value,
             specifiedType: const FullType.nullable(String),
           ) as String?;
           if (valueDes == null) continue;
-          result.fullName = valueDes;
+          result.baseUrl = valueDes;
           break;
-        case r'logoUrl':
+        case r'displayName':
           final valueDes = serializers.deserialize(
             value,
             specifiedType: const FullType.nullable(String),
           ) as String?;
           if (valueDes == null) continue;
-          result.logoUrl = valueDes;
-          break;
-        case r'profilePictureUrl':
-          final valueDes = serializers.deserialize(
-            value,
-            specifiedType: const FullType.nullable(String),
-          ) as String?;
-          if (valueDes == null) continue;
-          result.profilePictureUrl = valueDes;
+          result.displayName = valueDes;
           break;
         default:
           unhandled.add(key);
@@ -175,12 +144,12 @@ class _$MySchoolDtoSerializer implements PrimitiveSerializer<MySchoolDto> {
   }
 
   @override
-  MySchoolDto deserialize(
+  ConnectOdaOrgRequest deserialize(
     Serializers serializers,
     Object serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = MySchoolDtoBuilder();
+    final result = ConnectOdaOrgRequestBuilder();
     final serializedList = (serialized as Iterable<Object?>).toList();
     final unhandled = <Object?>[];
     _deserializeProperties(

--- a/lib/api/lib/src/model/connect_oda_org_request.g.dart
+++ b/lib/api/lib/src/model/connect_oda_org_request.g.dart
@@ -1,0 +1,133 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'connect_oda_org_request.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$ConnectOdaOrgRequest extends ConnectOdaOrgRequest {
+  @override
+  final String? username;
+  @override
+  final String? password;
+  @override
+  final String? baseUrl;
+  @override
+  final String? displayName;
+
+  factory _$ConnectOdaOrgRequest([
+    void Function(ConnectOdaOrgRequestBuilder)? updates,
+  ]) => (ConnectOdaOrgRequestBuilder()..update(updates))._build();
+
+  _$ConnectOdaOrgRequest._({
+    this.username,
+    this.password,
+    this.baseUrl,
+    this.displayName,
+  }) : super._();
+  @override
+  ConnectOdaOrgRequest rebuild(
+    void Function(ConnectOdaOrgRequestBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  ConnectOdaOrgRequestBuilder toBuilder() =>
+      ConnectOdaOrgRequestBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ConnectOdaOrgRequest &&
+        username == other.username &&
+        password == other.password &&
+        baseUrl == other.baseUrl &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, username.hashCode);
+    _$hash = $jc(_$hash, password.hashCode);
+    _$hash = $jc(_$hash, baseUrl.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ConnectOdaOrgRequest')
+          ..add('username', username)
+          ..add('password', password)
+          ..add('baseUrl', baseUrl)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class ConnectOdaOrgRequestBuilder
+    implements Builder<ConnectOdaOrgRequest, ConnectOdaOrgRequestBuilder> {
+  _$ConnectOdaOrgRequest? _$v;
+
+  String? _username;
+  String? get username => _$this._username;
+  set username(String? username) => _$this._username = username;
+
+  String? _password;
+  String? get password => _$this._password;
+  set password(String? password) => _$this._password = password;
+
+  String? _baseUrl;
+  String? get baseUrl => _$this._baseUrl;
+  set baseUrl(String? baseUrl) => _$this._baseUrl = baseUrl;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  ConnectOdaOrgRequestBuilder() {
+    ConnectOdaOrgRequest._defaults(this);
+  }
+
+  ConnectOdaOrgRequestBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _username = $v.username;
+      _password = $v.password;
+      _baseUrl = $v.baseUrl;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ConnectOdaOrgRequest other) {
+    _$v = other as _$ConnectOdaOrgRequest;
+  }
+
+  @override
+  void update(void Function(ConnectOdaOrgRequestBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ConnectOdaOrgRequest build() => _build();
+
+  _$ConnectOdaOrgRequest _build() {
+    final _$result =
+        _$v ??
+        _$ConnectOdaOrgRequest._(
+          username: username,
+          password: password,
+          baseUrl: baseUrl,
+          displayName: displayName,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/lib/api/lib/src/model/create_school_command.dart
+++ b/lib/api/lib/src/model/create_school_command.dart
@@ -21,6 +21,7 @@ part 'create_school_command.g.dart';
 /// * [state] 
 /// * [zip] 
 /// * [country] 
+/// * [logoUrl] 
 @BuiltValue()
 abstract class CreateSchoolCommand implements Built<CreateSchoolCommand, CreateSchoolCommandBuilder> {
   @BuiltValueField(wireName: r'name')
@@ -52,6 +53,9 @@ abstract class CreateSchoolCommand implements Built<CreateSchoolCommand, CreateS
 
   @BuiltValueField(wireName: r'country')
   String? get country;
+
+  @BuiltValueField(wireName: r'logoUrl')
+  String? get logoUrl;
 
   CreateSchoolCommand._();
 
@@ -143,6 +147,13 @@ class _$CreateSchoolCommandSerializer implements PrimitiveSerializer<CreateSchoo
       yield r'country';
       yield serializers.serialize(
         object.country,
+        specifiedType: const FullType.nullable(String),
+      );
+    }
+    if (object.logoUrl != null) {
+      yield r'logoUrl';
+      yield serializers.serialize(
+        object.logoUrl,
         specifiedType: const FullType.nullable(String),
       );
     }
@@ -248,6 +259,14 @@ class _$CreateSchoolCommandSerializer implements PrimitiveSerializer<CreateSchoo
           ) as String?;
           if (valueDes == null) continue;
           result.country = valueDes;
+          break;
+        case r'logoUrl':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType.nullable(String),
+          ) as String?;
+          if (valueDes == null) continue;
+          result.logoUrl = valueDes;
           break;
         default:
           unhandled.add(key);

--- a/lib/api/lib/src/model/create_school_command.g.dart
+++ b/lib/api/lib/src/model/create_school_command.g.dart
@@ -27,6 +27,8 @@ class _$CreateSchoolCommand extends CreateSchoolCommand {
   final String? zip;
   @override
   final String? country;
+  @override
+  final String? logoUrl;
 
   factory _$CreateSchoolCommand([
     void Function(CreateSchoolCommandBuilder)? updates,
@@ -43,6 +45,7 @@ class _$CreateSchoolCommand extends CreateSchoolCommand {
     this.state,
     this.zip,
     this.country,
+    this.logoUrl,
   }) : super._();
   @override
   CreateSchoolCommand rebuild(
@@ -66,7 +69,8 @@ class _$CreateSchoolCommand extends CreateSchoolCommand {
         city == other.city &&
         state == other.state &&
         zip == other.zip &&
-        country == other.country;
+        country == other.country &&
+        logoUrl == other.logoUrl;
   }
 
   @override
@@ -82,6 +86,7 @@ class _$CreateSchoolCommand extends CreateSchoolCommand {
     _$hash = $jc(_$hash, state.hashCode);
     _$hash = $jc(_$hash, zip.hashCode);
     _$hash = $jc(_$hash, country.hashCode);
+    _$hash = $jc(_$hash, logoUrl.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -98,7 +103,8 @@ class _$CreateSchoolCommand extends CreateSchoolCommand {
           ..add('city', city)
           ..add('state', state)
           ..add('zip', zip)
-          ..add('country', country))
+          ..add('country', country)
+          ..add('logoUrl', logoUrl))
         .toString();
   }
 }
@@ -147,6 +153,10 @@ class CreateSchoolCommandBuilder
   String? get country => _$this._country;
   set country(String? country) => _$this._country = country;
 
+  String? _logoUrl;
+  String? get logoUrl => _$this._logoUrl;
+  set logoUrl(String? logoUrl) => _$this._logoUrl = logoUrl;
+
   CreateSchoolCommandBuilder() {
     CreateSchoolCommand._defaults(this);
   }
@@ -164,6 +174,7 @@ class CreateSchoolCommandBuilder
       _state = $v.state;
       _zip = $v.zip;
       _country = $v.country;
+      _logoUrl = $v.logoUrl;
       _$v = null;
     }
     return this;
@@ -196,6 +207,7 @@ class CreateSchoolCommandBuilder
           state: state,
           zip: zip,
           country: country,
+          logoUrl: logoUrl,
         );
     replace(_$result);
     return _$result;

--- a/lib/api/lib/src/model/create_school_user_command.dart
+++ b/lib/api/lib/src/model/create_school_user_command.dart
@@ -26,6 +26,7 @@ part 'create_school_user_command.g.dart';
 /// * [birthday] 
 /// * [entryDate] 
 /// * [role] 
+/// * [profilePictureUrl] 
 @BuiltValue()
 abstract class CreateSchoolUserCommand implements Built<CreateSchoolUserCommand, CreateSchoolUserCommandBuilder> {
   @BuiltValueField(wireName: r'applicationUserId')
@@ -67,6 +68,9 @@ abstract class CreateSchoolUserCommand implements Built<CreateSchoolUserCommand,
   @BuiltValueField(wireName: r'role')
   Roles? get role;
   // enum roleEnum {  Student,  Teacher,  Administrator,  };
+
+  @BuiltValueField(wireName: r'profilePictureUrl')
+  String? get profilePictureUrl;
 
   CreateSchoolUserCommand._();
 
@@ -180,6 +184,13 @@ class _$CreateSchoolUserCommandSerializer implements PrimitiveSerializer<CreateS
       yield serializers.serialize(
         object.role,
         specifiedType: const FullType(Roles),
+      );
+    }
+    if (object.profilePictureUrl != null) {
+      yield r'profilePictureUrl';
+      yield serializers.serialize(
+        object.profilePictureUrl,
+        specifiedType: const FullType.nullable(String),
       );
     }
   }
@@ -303,6 +314,14 @@ class _$CreateSchoolUserCommandSerializer implements PrimitiveSerializer<CreateS
             specifiedType: const FullType(Roles),
           ) as Roles;
           result.role = valueDes;
+          break;
+        case r'profilePictureUrl':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType.nullable(String),
+          ) as String?;
+          if (valueDes == null) continue;
+          result.profilePictureUrl = valueDes;
           break;
         default:
           unhandled.add(key);

--- a/lib/api/lib/src/model/create_school_user_command.g.dart
+++ b/lib/api/lib/src/model/create_school_user_command.g.dart
@@ -33,6 +33,8 @@ class _$CreateSchoolUserCommand extends CreateSchoolUserCommand {
   final Date? entryDate;
   @override
   final Roles? role;
+  @override
+  final String? profilePictureUrl;
 
   factory _$CreateSchoolUserCommand([
     void Function(CreateSchoolUserCommandBuilder)? updates,
@@ -52,6 +54,7 @@ class _$CreateSchoolUserCommand extends CreateSchoolUserCommand {
     this.birthday,
     this.entryDate,
     this.role,
+    this.profilePictureUrl,
   }) : super._();
   @override
   CreateSchoolUserCommand rebuild(
@@ -78,7 +81,8 @@ class _$CreateSchoolUserCommand extends CreateSchoolUserCommand {
         zip == other.zip &&
         birthday == other.birthday &&
         entryDate == other.entryDate &&
-        role == other.role;
+        role == other.role &&
+        profilePictureUrl == other.profilePictureUrl;
   }
 
   @override
@@ -97,6 +101,7 @@ class _$CreateSchoolUserCommand extends CreateSchoolUserCommand {
     _$hash = $jc(_$hash, birthday.hashCode);
     _$hash = $jc(_$hash, entryDate.hashCode);
     _$hash = $jc(_$hash, role.hashCode);
+    _$hash = $jc(_$hash, profilePictureUrl.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -116,7 +121,8 @@ class _$CreateSchoolUserCommand extends CreateSchoolUserCommand {
           ..add('zip', zip)
           ..add('birthday', birthday)
           ..add('entryDate', entryDate)
-          ..add('role', role))
+          ..add('role', role)
+          ..add('profilePictureUrl', profilePictureUrl))
         .toString();
   }
 }
@@ -179,6 +185,11 @@ class CreateSchoolUserCommandBuilder
   Roles? get role => _$this._role;
   set role(Roles? role) => _$this._role = role;
 
+  String? _profilePictureUrl;
+  String? get profilePictureUrl => _$this._profilePictureUrl;
+  set profilePictureUrl(String? profilePictureUrl) =>
+      _$this._profilePictureUrl = profilePictureUrl;
+
   CreateSchoolUserCommandBuilder() {
     CreateSchoolUserCommand._defaults(this);
   }
@@ -199,6 +210,7 @@ class CreateSchoolUserCommandBuilder
       _birthday = $v.birthday;
       _entryDate = $v.entryDate;
       _role = $v.role;
+      _profilePictureUrl = $v.profilePictureUrl;
       _$v = null;
     }
     return this;
@@ -234,6 +246,7 @@ class CreateSchoolUserCommandBuilder
           birthday: birthday,
           entryDate: entryDate,
           role: role,
+          profilePictureUrl: profilePictureUrl,
         );
     replace(_$result);
     return _$result;

--- a/lib/api/lib/src/model/my_school_dto.g.dart
+++ b/lib/api/lib/src/model/my_school_dto.g.dart
@@ -15,11 +15,22 @@ class _$MySchoolDto extends MySchoolDto {
   final String? email;
   @override
   final String? fullName;
+  @override
+  final String? logoUrl;
+  @override
+  final String? profilePictureUrl;
 
   factory _$MySchoolDto([void Function(MySchoolDtoBuilder)? updates]) =>
       (MySchoolDtoBuilder()..update(updates))._build();
 
-  _$MySchoolDto._({this.id, this.name, this.email, this.fullName}) : super._();
+  _$MySchoolDto._({
+    this.id,
+    this.name,
+    this.email,
+    this.fullName,
+    this.logoUrl,
+    this.profilePictureUrl,
+  }) : super._();
   @override
   MySchoolDto rebuild(void Function(MySchoolDtoBuilder) updates) =>
       (toBuilder()..update(updates)).build();
@@ -34,7 +45,9 @@ class _$MySchoolDto extends MySchoolDto {
         id == other.id &&
         name == other.name &&
         email == other.email &&
-        fullName == other.fullName;
+        fullName == other.fullName &&
+        logoUrl == other.logoUrl &&
+        profilePictureUrl == other.profilePictureUrl;
   }
 
   @override
@@ -44,6 +57,8 @@ class _$MySchoolDto extends MySchoolDto {
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, email.hashCode);
     _$hash = $jc(_$hash, fullName.hashCode);
+    _$hash = $jc(_$hash, logoUrl.hashCode);
+    _$hash = $jc(_$hash, profilePictureUrl.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -54,7 +69,9 @@ class _$MySchoolDto extends MySchoolDto {
           ..add('id', id)
           ..add('name', name)
           ..add('email', email)
-          ..add('fullName', fullName))
+          ..add('fullName', fullName)
+          ..add('logoUrl', logoUrl)
+          ..add('profilePictureUrl', profilePictureUrl))
         .toString();
   }
 }
@@ -78,6 +95,15 @@ class MySchoolDtoBuilder implements Builder<MySchoolDto, MySchoolDtoBuilder> {
   String? get fullName => _$this._fullName;
   set fullName(String? fullName) => _$this._fullName = fullName;
 
+  String? _logoUrl;
+  String? get logoUrl => _$this._logoUrl;
+  set logoUrl(String? logoUrl) => _$this._logoUrl = logoUrl;
+
+  String? _profilePictureUrl;
+  String? get profilePictureUrl => _$this._profilePictureUrl;
+  set profilePictureUrl(String? profilePictureUrl) =>
+      _$this._profilePictureUrl = profilePictureUrl;
+
   MySchoolDtoBuilder() {
     MySchoolDto._defaults(this);
   }
@@ -89,6 +115,8 @@ class MySchoolDtoBuilder implements Builder<MySchoolDto, MySchoolDtoBuilder> {
       _name = $v.name;
       _email = $v.email;
       _fullName = $v.fullName;
+      _logoUrl = $v.logoUrl;
+      _profilePictureUrl = $v.profilePictureUrl;
       _$v = null;
     }
     return this;
@@ -110,7 +138,14 @@ class MySchoolDtoBuilder implements Builder<MySchoolDto, MySchoolDtoBuilder> {
   _$MySchoolDto _build() {
     final _$result =
         _$v ??
-        _$MySchoolDto._(id: id, name: name, email: email, fullName: fullName);
+        _$MySchoolDto._(
+          id: id,
+          name: name,
+          email: email,
+          fullName: fullName,
+          logoUrl: logoUrl,
+          profilePictureUrl: profilePictureUrl,
+        );
     replace(_$result);
     return _$result;
   }

--- a/lib/api/lib/src/model/school_dto.dart
+++ b/lib/api/lib/src/model/school_dto.dart
@@ -22,6 +22,7 @@ part 'school_dto.g.dart';
 /// * [state] 
 /// * [zip] 
 /// * [country] 
+/// * [logoUrl] 
 /// * [createdAt] 
 /// * [updatedAt] 
 @BuiltValue()
@@ -58,6 +59,9 @@ abstract class SchoolDto implements Built<SchoolDto, SchoolDtoBuilder> {
 
   @BuiltValueField(wireName: r'country')
   String? get country;
+
+  @BuiltValueField(wireName: r'logoUrl')
+  String? get logoUrl;
 
   @BuiltValueField(wireName: r'createdAt')
   DateTime? get createdAt;
@@ -160,6 +164,13 @@ class _$SchoolDtoSerializer implements PrimitiveSerializer<SchoolDto> {
       yield r'country';
       yield serializers.serialize(
         object.country,
+        specifiedType: const FullType.nullable(String),
+      );
+    }
+    if (object.logoUrl != null) {
+      yield r'logoUrl';
+      yield serializers.serialize(
+        object.logoUrl,
         specifiedType: const FullType.nullable(String),
       );
     }
@@ -286,6 +297,14 @@ class _$SchoolDtoSerializer implements PrimitiveSerializer<SchoolDto> {
           ) as String?;
           if (valueDes == null) continue;
           result.country = valueDes;
+          break;
+        case r'logoUrl':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType.nullable(String),
+          ) as String?;
+          if (valueDes == null) continue;
+          result.logoUrl = valueDes;
           break;
         case r'createdAt':
           final valueDes = serializers.deserialize(

--- a/lib/api/lib/src/model/school_dto.g.dart
+++ b/lib/api/lib/src/model/school_dto.g.dart
@@ -30,6 +30,8 @@ class _$SchoolDto extends SchoolDto {
   @override
   final String? country;
   @override
+  final String? logoUrl;
+  @override
   final DateTime? createdAt;
   @override
   final DateTime? updatedAt;
@@ -49,6 +51,7 @@ class _$SchoolDto extends SchoolDto {
     this.state,
     this.zip,
     this.country,
+    this.logoUrl,
     this.createdAt,
     this.updatedAt,
   }) : super._();
@@ -74,6 +77,7 @@ class _$SchoolDto extends SchoolDto {
         state == other.state &&
         zip == other.zip &&
         country == other.country &&
+        logoUrl == other.logoUrl &&
         createdAt == other.createdAt &&
         updatedAt == other.updatedAt;
   }
@@ -92,6 +96,7 @@ class _$SchoolDto extends SchoolDto {
     _$hash = $jc(_$hash, state.hashCode);
     _$hash = $jc(_$hash, zip.hashCode);
     _$hash = $jc(_$hash, country.hashCode);
+    _$hash = $jc(_$hash, logoUrl.hashCode);
     _$hash = $jc(_$hash, createdAt.hashCode);
     _$hash = $jc(_$hash, updatedAt.hashCode);
     _$hash = $jf(_$hash);
@@ -112,6 +117,7 @@ class _$SchoolDto extends SchoolDto {
           ..add('state', state)
           ..add('zip', zip)
           ..add('country', country)
+          ..add('logoUrl', logoUrl)
           ..add('createdAt', createdAt)
           ..add('updatedAt', updatedAt))
         .toString();
@@ -165,6 +171,10 @@ class SchoolDtoBuilder implements Builder<SchoolDto, SchoolDtoBuilder> {
   String? get country => _$this._country;
   set country(String? country) => _$this._country = country;
 
+  String? _logoUrl;
+  String? get logoUrl => _$this._logoUrl;
+  set logoUrl(String? logoUrl) => _$this._logoUrl = logoUrl;
+
   DateTime? _createdAt;
   DateTime? get createdAt => _$this._createdAt;
   set createdAt(DateTime? createdAt) => _$this._createdAt = createdAt;
@@ -191,6 +201,7 @@ class SchoolDtoBuilder implements Builder<SchoolDto, SchoolDtoBuilder> {
       _state = $v.state;
       _zip = $v.zip;
       _country = $v.country;
+      _logoUrl = $v.logoUrl;
       _createdAt = $v.createdAt;
       _updatedAt = $v.updatedAt;
       _$v = null;
@@ -226,6 +237,7 @@ class SchoolDtoBuilder implements Builder<SchoolDto, SchoolDtoBuilder> {
           state: state,
           zip: zip,
           country: country,
+          logoUrl: logoUrl,
           createdAt: createdAt,
           updatedAt: updatedAt,
         );

--- a/lib/api/lib/src/model/school_user_dto.dart
+++ b/lib/api/lib/src/model/school_user_dto.dart
@@ -27,6 +27,7 @@ part 'school_user_dto.g.dart';
 /// * [email] 
 /// * [privateEmail] 
 /// * [phoneNumber] 
+/// * [profilePictureUrl] 
 /// * [street] 
 /// * [city] 
 /// * [zip] 
@@ -68,6 +69,9 @@ abstract class SchoolUserDto implements Built<SchoolUserDto, SchoolUserDtoBuilde
 
   @BuiltValueField(wireName: r'phoneNumber')
   String? get phoneNumber;
+
+  @BuiltValueField(wireName: r'profilePictureUrl')
+  String? get profilePictureUrl;
 
   @BuiltValueField(wireName: r'street')
   String? get street;
@@ -187,6 +191,13 @@ class _$SchoolUserDtoSerializer implements PrimitiveSerializer<SchoolUserDto> {
       yield r'phoneNumber';
       yield serializers.serialize(
         object.phoneNumber,
+        specifiedType: const FullType.nullable(String),
+      );
+    }
+    if (object.profilePictureUrl != null) {
+      yield r'profilePictureUrl';
+      yield serializers.serialize(
+        object.profilePictureUrl,
         specifiedType: const FullType.nullable(String),
       );
     }
@@ -366,6 +377,14 @@ class _$SchoolUserDtoSerializer implements PrimitiveSerializer<SchoolUserDto> {
           ) as String?;
           if (valueDes == null) continue;
           result.phoneNumber = valueDes;
+          break;
+        case r'profilePictureUrl':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType.nullable(String),
+          ) as String?;
+          if (valueDes == null) continue;
+          result.profilePictureUrl = valueDes;
           break;
         case r'street':
           final valueDes = serializers.deserialize(

--- a/lib/api/lib/src/model/school_user_dto.g.dart
+++ b/lib/api/lib/src/model/school_user_dto.g.dart
@@ -26,6 +26,8 @@ class _$SchoolUserDto extends SchoolUserDto {
   @override
   final String? phoneNumber;
   @override
+  final String? profilePictureUrl;
+  @override
   final String? street;
   @override
   final String? city;
@@ -65,6 +67,7 @@ class _$SchoolUserDto extends SchoolUserDto {
     this.email,
     this.privateEmail,
     this.phoneNumber,
+    this.profilePictureUrl,
     this.street,
     this.city,
     this.zip,
@@ -99,6 +102,7 @@ class _$SchoolUserDto extends SchoolUserDto {
         email == other.email &&
         privateEmail == other.privateEmail &&
         phoneNumber == other.phoneNumber &&
+        profilePictureUrl == other.profilePictureUrl &&
         street == other.street &&
         city == other.city &&
         zip == other.zip &&
@@ -126,6 +130,7 @@ class _$SchoolUserDto extends SchoolUserDto {
     _$hash = $jc(_$hash, email.hashCode);
     _$hash = $jc(_$hash, privateEmail.hashCode);
     _$hash = $jc(_$hash, phoneNumber.hashCode);
+    _$hash = $jc(_$hash, profilePictureUrl.hashCode);
     _$hash = $jc(_$hash, street.hashCode);
     _$hash = $jc(_$hash, city.hashCode);
     _$hash = $jc(_$hash, zip.hashCode);
@@ -155,6 +160,7 @@ class _$SchoolUserDto extends SchoolUserDto {
           ..add('email', email)
           ..add('privateEmail', privateEmail)
           ..add('phoneNumber', phoneNumber)
+          ..add('profilePictureUrl', profilePictureUrl)
           ..add('street', street)
           ..add('city', city)
           ..add('zip', zip)
@@ -212,6 +218,11 @@ class SchoolUserDtoBuilder
   String? _phoneNumber;
   String? get phoneNumber => _$this._phoneNumber;
   set phoneNumber(String? phoneNumber) => _$this._phoneNumber = phoneNumber;
+
+  String? _profilePictureUrl;
+  String? get profilePictureUrl => _$this._profilePictureUrl;
+  set profilePictureUrl(String? profilePictureUrl) =>
+      _$this._profilePictureUrl = profilePictureUrl;
 
   String? _street;
   String? get street => _$this._street;
@@ -285,6 +296,7 @@ class SchoolUserDtoBuilder
       _email = $v.email;
       _privateEmail = $v.privateEmail;
       _phoneNumber = $v.phoneNumber;
+      _profilePictureUrl = $v.profilePictureUrl;
       _street = $v.street;
       _city = $v.city;
       _zip = $v.zip;
@@ -331,6 +343,7 @@ class SchoolUserDtoBuilder
             email: email,
             privateEmail: privateEmail,
             phoneNumber: phoneNumber,
+            profilePictureUrl: profilePictureUrl,
             street: street,
             city: city,
             zip: zip,

--- a/lib/api/lib/src/model/update_school_command.dart
+++ b/lib/api/lib/src/model/update_school_command.dart
@@ -22,6 +22,7 @@ part 'update_school_command.g.dart';
 /// * [state] 
 /// * [zip] 
 /// * [country] 
+/// * [logoUrl] 
 @BuiltValue()
 abstract class UpdateSchoolCommand implements Built<UpdateSchoolCommand, UpdateSchoolCommandBuilder> {
   @BuiltValueField(wireName: r'id')
@@ -56,6 +57,9 @@ abstract class UpdateSchoolCommand implements Built<UpdateSchoolCommand, UpdateS
 
   @BuiltValueField(wireName: r'country')
   String? get country;
+
+  @BuiltValueField(wireName: r'logoUrl')
+  String? get logoUrl;
 
   UpdateSchoolCommand._();
 
@@ -154,6 +158,13 @@ class _$UpdateSchoolCommandSerializer implements PrimitiveSerializer<UpdateSchoo
       yield r'country';
       yield serializers.serialize(
         object.country,
+        specifiedType: const FullType.nullable(String),
+      );
+    }
+    if (object.logoUrl != null) {
+      yield r'logoUrl';
+      yield serializers.serialize(
+        object.logoUrl,
         specifiedType: const FullType.nullable(String),
       );
     }
@@ -266,6 +277,14 @@ class _$UpdateSchoolCommandSerializer implements PrimitiveSerializer<UpdateSchoo
           ) as String?;
           if (valueDes == null) continue;
           result.country = valueDes;
+          break;
+        case r'logoUrl':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType.nullable(String),
+          ) as String?;
+          if (valueDes == null) continue;
+          result.logoUrl = valueDes;
           break;
         default:
           unhandled.add(key);

--- a/lib/api/lib/src/model/update_school_command.g.dart
+++ b/lib/api/lib/src/model/update_school_command.g.dart
@@ -29,6 +29,8 @@ class _$UpdateSchoolCommand extends UpdateSchoolCommand {
   final String? zip;
   @override
   final String? country;
+  @override
+  final String? logoUrl;
 
   factory _$UpdateSchoolCommand([
     void Function(UpdateSchoolCommandBuilder)? updates,
@@ -46,6 +48,7 @@ class _$UpdateSchoolCommand extends UpdateSchoolCommand {
     this.state,
     this.zip,
     this.country,
+    this.logoUrl,
   }) : super._();
   @override
   UpdateSchoolCommand rebuild(
@@ -70,7 +73,8 @@ class _$UpdateSchoolCommand extends UpdateSchoolCommand {
         city == other.city &&
         state == other.state &&
         zip == other.zip &&
-        country == other.country;
+        country == other.country &&
+        logoUrl == other.logoUrl;
   }
 
   @override
@@ -87,6 +91,7 @@ class _$UpdateSchoolCommand extends UpdateSchoolCommand {
     _$hash = $jc(_$hash, state.hashCode);
     _$hash = $jc(_$hash, zip.hashCode);
     _$hash = $jc(_$hash, country.hashCode);
+    _$hash = $jc(_$hash, logoUrl.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -104,7 +109,8 @@ class _$UpdateSchoolCommand extends UpdateSchoolCommand {
           ..add('city', city)
           ..add('state', state)
           ..add('zip', zip)
-          ..add('country', country))
+          ..add('country', country)
+          ..add('logoUrl', logoUrl))
         .toString();
   }
 }
@@ -157,6 +163,10 @@ class UpdateSchoolCommandBuilder
   String? get country => _$this._country;
   set country(String? country) => _$this._country = country;
 
+  String? _logoUrl;
+  String? get logoUrl => _$this._logoUrl;
+  set logoUrl(String? logoUrl) => _$this._logoUrl = logoUrl;
+
   UpdateSchoolCommandBuilder() {
     UpdateSchoolCommand._defaults(this);
   }
@@ -175,6 +185,7 @@ class UpdateSchoolCommandBuilder
       _state = $v.state;
       _zip = $v.zip;
       _country = $v.country;
+      _logoUrl = $v.logoUrl;
       _$v = null;
     }
     return this;
@@ -208,6 +219,7 @@ class UpdateSchoolCommandBuilder
           state: state,
           zip: zip,
           country: country,
+          logoUrl: logoUrl,
         );
     replace(_$result);
     return _$result;

--- a/lib/api/lib/src/model/update_school_user_command.dart
+++ b/lib/api/lib/src/model/update_school_user_command.dart
@@ -24,6 +24,7 @@ part 'update_school_user_command.g.dart';
 /// * [zip] 
 /// * [leaveDate] 
 /// * [state] 
+/// * [profilePictureUrl] 
 @BuiltValue()
 abstract class UpdateSchoolUserCommand implements Built<UpdateSchoolUserCommand, UpdateSchoolUserCommandBuilder> {
   @BuiltValueField(wireName: r'schoolUserId')
@@ -59,6 +60,9 @@ abstract class UpdateSchoolUserCommand implements Built<UpdateSchoolUserCommand,
   @BuiltValueField(wireName: r'state')
   UserState? get state;
   // enum stateEnum {  None,  Active,  Inactive,  };
+
+  @BuiltValueField(wireName: r'profilePictureUrl')
+  String? get profilePictureUrl;
 
   UpdateSchoolUserCommand._();
 
@@ -158,6 +162,13 @@ class _$UpdateSchoolUserCommandSerializer implements PrimitiveSerializer<UpdateS
       yield serializers.serialize(
         object.state,
         specifiedType: const FullType(UserState),
+      );
+    }
+    if (object.profilePictureUrl != null) {
+      yield r'profilePictureUrl';
+      yield serializers.serialize(
+        object.profilePictureUrl,
+        specifiedType: const FullType.nullable(String),
       );
     }
   }
@@ -268,6 +279,14 @@ class _$UpdateSchoolUserCommandSerializer implements PrimitiveSerializer<UpdateS
             specifiedType: const FullType(UserState),
           ) as UserState;
           result.state = valueDes;
+          break;
+        case r'profilePictureUrl':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType.nullable(String),
+          ) as String?;
+          if (valueDes == null) continue;
+          result.profilePictureUrl = valueDes;
           break;
         default:
           unhandled.add(key);

--- a/lib/api/lib/src/model/update_school_user_command.g.dart
+++ b/lib/api/lib/src/model/update_school_user_command.g.dart
@@ -29,6 +29,8 @@ class _$UpdateSchoolUserCommand extends UpdateSchoolUserCommand {
   final Date? leaveDate;
   @override
   final UserState? state;
+  @override
+  final String? profilePictureUrl;
 
   factory _$UpdateSchoolUserCommand([
     void Function(UpdateSchoolUserCommandBuilder)? updates,
@@ -46,6 +48,7 @@ class _$UpdateSchoolUserCommand extends UpdateSchoolUserCommand {
     this.zip,
     this.leaveDate,
     this.state,
+    this.profilePictureUrl,
   }) : super._();
   @override
   UpdateSchoolUserCommand rebuild(
@@ -70,7 +73,8 @@ class _$UpdateSchoolUserCommand extends UpdateSchoolUserCommand {
         city == other.city &&
         zip == other.zip &&
         leaveDate == other.leaveDate &&
-        state == other.state;
+        state == other.state &&
+        profilePictureUrl == other.profilePictureUrl;
   }
 
   @override
@@ -87,6 +91,7 @@ class _$UpdateSchoolUserCommand extends UpdateSchoolUserCommand {
     _$hash = $jc(_$hash, zip.hashCode);
     _$hash = $jc(_$hash, leaveDate.hashCode);
     _$hash = $jc(_$hash, state.hashCode);
+    _$hash = $jc(_$hash, profilePictureUrl.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -104,7 +109,8 @@ class _$UpdateSchoolUserCommand extends UpdateSchoolUserCommand {
           ..add('city', city)
           ..add('zip', zip)
           ..add('leaveDate', leaveDate)
-          ..add('state', state))
+          ..add('state', state)
+          ..add('profilePictureUrl', profilePictureUrl))
         .toString();
   }
 }
@@ -158,6 +164,11 @@ class UpdateSchoolUserCommandBuilder
   UserState? get state => _$this._state;
   set state(UserState? state) => _$this._state = state;
 
+  String? _profilePictureUrl;
+  String? get profilePictureUrl => _$this._profilePictureUrl;
+  set profilePictureUrl(String? profilePictureUrl) =>
+      _$this._profilePictureUrl = profilePictureUrl;
+
   UpdateSchoolUserCommandBuilder() {
     UpdateSchoolUserCommand._defaults(this);
   }
@@ -176,6 +187,7 @@ class UpdateSchoolUserCommandBuilder
       _zip = $v.zip;
       _leaveDate = $v.leaveDate;
       _state = $v.state;
+      _profilePictureUrl = $v.profilePictureUrl;
       _$v = null;
     }
     return this;
@@ -209,6 +221,7 @@ class UpdateSchoolUserCommandBuilder
           zip: zip,
           leaveDate: leaveDate,
           state: state,
+          profilePictureUrl: profilePictureUrl,
         );
     replace(_$result);
     return _$result;

--- a/lib/api/lib/src/serializers.dart
+++ b/lib/api/lib/src/serializers.dart
@@ -23,6 +23,7 @@ import 'package:schuly_api/src/model/app_dto.dart';
 import 'package:schuly_api/src/model/application_user_dto.dart';
 import 'package:schuly_api/src/model/class_dto.dart';
 import 'package:schuly_api/src/model/connect_account_request.dart';
+import 'package:schuly_api/src/model/connect_oda_org_request.dart';
 import 'package:schuly_api/src/model/create_absence_command.dart';
 import 'package:schuly_api/src/model/create_agenda_entry_command.dart';
 import 'package:schuly_api/src/model/create_application_user_command.dart';
@@ -70,6 +71,7 @@ part 'serializers.g.dart';
   ApplicationUserDto,
   ClassDto,
   ConnectAccountRequest,
+  ConnectOdaOrgRequest,
   CreateAbsenceCommand,
   CreateAgendaEntryCommand,
   CreateApplicationUserCommand,

--- a/lib/api/lib/src/serializers.g.dart
+++ b/lib/api/lib/src/serializers.g.dart
@@ -17,6 +17,7 @@ Serializers _$serializers =
           ..add(ApplicationUserDto.serializer)
           ..add(ClassDto.serializer)
           ..add(ConnectAccountRequest.serializer)
+          ..add(ConnectOdaOrgRequest.serializer)
           ..add(CreateAbsenceCommand.serializer)
           ..add(CreateAgendaEntryCommand.serializer)
           ..add(CreateApplicationUserCommand.serializer)

--- a/lib/api/test/connect_oda_org_request_test.dart
+++ b/lib/api/test/connect_oda_org_request_test.dart
@@ -1,0 +1,31 @@
+import 'package:test/test.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+// tests for ConnectOdaOrgRequest
+void main() {
+  final instance = ConnectOdaOrgRequestBuilder();
+  // TODO add properties to the builder and call build()
+
+  group(ConnectOdaOrgRequest, () {
+    // String username
+    test('to test the property `username`', () async {
+      // TODO
+    });
+
+    // String password
+    test('to test the property `password`', () async {
+      // TODO
+    });
+
+    // String baseUrl
+    test('to test the property `baseUrl`', () async {
+      // TODO
+    });
+
+    // String displayName
+    test('to test the property `displayName`', () async {
+      // TODO
+    });
+
+  });
+}

--- a/lib/config/oidc_config.dart
+++ b/lib/config/oidc_config.dart
@@ -11,10 +11,9 @@ class OidcConfig {
   static const redirectUri = 'schulytest://callback';
   static const callbackScheme = 'schulytest';
 
-  // LAN address of the dev box. The device must be on the same network.
-  // Alternatives: `http://localhost:5033` + `adb reverse tcp:5033 tcp:5033`
-  // for a USB-tethered phone, or `http://10.0.2.2:5033` for the emulator.
-  static const backendBaseUrl = 'http://192.168.188.93:5033';
+  // Android emulator loopback to the host. Use the LAN IP
+  // (http://192.168.188.93:5033) for a physical device on the same network.
+  static const backendBaseUrl = 'http://10.0.2.2:5033';
 
   static const tokenEndpoint = '$authority/api/oidc/token';
   static const authorizationEndpoint = '$authority/authorize';

--- a/lib/domain/schulware_account.dart
+++ b/lib/domain/schulware_account.dart
@@ -2,24 +2,34 @@ import 'package:schuly_api/schuly_api.dart';
 
 /// A school the signed-in user belongs to, from `GET /api/schools/my-schools`.
 /// Carries the school name plus the user's identity (full name + email) at
-/// that school — what the account switcher displays.
+/// that school — what the account switcher displays. [provider] is inferred
+/// from which plugin owns the school's SchoolUser (the API doesn't expose it).
 class MySchool {
   final String id;
   final String name;
   final String? email;
   final String? fullName;
+  final String provider; // 'schulnetz' | 'odaorg'
 
   const MySchool({
     required this.id,
     required this.name,
     this.email,
     this.fullName,
+    this.provider = 'schulnetz',
   });
 
-  factory MySchool.fromDto(MySchoolDto dto) => MySchool(
+  factory MySchool.fromDto(MySchoolDto dto, {String provider = 'schulnetz'}) => MySchool(
         id: dto.id ?? '',
         name: (dto.name?.isNotEmpty ?? false) ? dto.name! : 'School',
         email: dto.email,
         fullName: dto.fullName,
+        provider: provider,
       );
+
+  /// Asset for this provider's logo.
+  String get logoAsset => switch (provider) {
+        'odaorg' => 'assets/schoolsystems/odaorg.webp',
+        _ => 'assets/schoolsystems/schulnetz.webp',
+      };
 }

--- a/lib/services/active_account_service.dart
+++ b/lib/services/active_account_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:schuly_api/schuly_api.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../domain/schulware_account.dart';
@@ -38,13 +39,17 @@ class ActiveAccountService extends ChangeNotifier {
     _error = null;
     notifyListeners();
     try {
-      final res = await ApiClient.instance.api
-          .getSchoolsApi()
-          .apiSchoolsMySchoolsGet();
+      final api = ApiClient.instance.api;
+      final res = await api.getSchoolsApi().apiSchoolsMySchoolsGet();
       final data = res.data;
+
+      final providerBySchoolId = await _detectProviders();
       _schools = data == null
           ? const []
-          : data.map(MySchool.fromDto).toList(growable: false);
+          : data
+              .map((dto) => MySchool.fromDto(dto,
+                  provider: providerBySchoolId[dto.id] ?? 'schulnetz'))
+              .toList(growable: false);
 
       // Keep the persisted active id only if it still resolves to a school.
       final prefs = await SharedPreferences.getInstance();
@@ -64,6 +69,38 @@ class ActiveAccountService extends ChangeNotifier {
     } finally {
       _loading = false;
       notifyListeners();
+    }
+  }
+
+  /// Maps schoolId → provider by cross-referencing the OdaOrg plugin's
+  /// accounts (which expose `schoolUserId`) against the user's SchoolUsers.
+  /// Anything not owned by OdaOrg defaults to Schulnetz. Best-effort: returns
+  /// an empty map on any failure so the account list still loads.
+  Future<Map<String, String>> _detectProviders() async {
+    try {
+      final api = ApiClient.instance.api;
+      final me = await api.getAuthApi().apiAuthMeGet();
+      final appUserId = me.data?.id;
+      if (appUserId == null) return const {};
+
+      final usersRes =
+          await api.getSchoolUsersApi().apiSchoolUsersGet(applicationUserId: appUserId);
+      final schoolIdByUser = <String, String>{
+        for (final u in (usersRes.data ?? const <SchoolUserDto>[]))
+          if (u.id != null && u.schoolId != null) u.id!: u.schoolId!,
+      };
+
+      final odaRes = await api.getAccountsApi().apiPluginsOdaorgAccountsGet();
+      final odaAccounts = (odaRes.data as List<dynamic>?) ?? const [];
+      final out = <String, String>{};
+      for (final a in odaAccounts.cast<Map<String, dynamic>>()) {
+        final suId = a['schoolUserId'] as String?;
+        final schoolId = suId == null ? null : schoolIdByUser[suId];
+        if (schoolId != null) out[schoolId] = 'odaorg';
+      }
+      return out;
+    } catch (_) {
+      return const {};
     }
   }
 

--- a/lib/services/school_data_service.dart
+++ b/lib/services/school_data_service.dart
@@ -87,9 +87,14 @@ class SchoolDataService extends ChangeNotifier {
           .where((e) => e.schoolId == schoolId)
           .toList(growable: false);
 
+      // Agenda entries carry a classId but no schoolId, so scope them by the
+      // user's classes (their classes all belong to the active school).
+      final myClassIds = {
+        for (final c in (_me?.classes ?? const <UserClassDto>[])) c.classId,
+      };
       final agenda = await _api.getAgendasApi().apiAgendasGet();
       _agenda = (agenda.data ?? BuiltList<AgendaEntryDto>())
-          .where((a) => a.schoolId == schoolId)
+          .where((a) => myClassIds.isEmpty || myClassIds.contains(a.classId))
           .toList(growable: false);
 
       final absences = await _api.getAbsencesApi().apiAbsencesGet();

--- a/lib/ui/absences/absences_page.dart
+++ b/lib/ui/absences/absences_page.dart
@@ -1,0 +1,309 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+import '../../services/api_client.dart';
+import '../../services/school_data_service.dart';
+
+/// Absences tab — lists the user's absences/delays and lets them report,
+/// edit, and delete (the one writable area).
+class AbsencesPage extends StatelessWidget {
+  const AbsencesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final svc = SchoolDataService.instance;
+    final absences = svc.absences.toList()
+      ..sort((a, b) => b.from.compareTo(a.from));
+
+    final delays = absences.where((a) => a.type == AbsenceType.delay).length;
+
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      floatingActionButton: FButton(
+        mainAxisSize: MainAxisSize.min,
+        prefix: const Icon(FIcons.plus),
+        onPress: svc.me == null ? null : () => _openForm(context),
+        child: const Text('Report'),
+      ),
+      body: RefreshIndicator(
+        onRefresh: svc.refresh,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 88),
+          children: [
+            FCard(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    _Stat(label: 'Total', value: '${absences.length}'),
+                    _Stat(label: 'Delays', value: '$delays'),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            if (absences.isEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 40),
+                child: Center(
+                  child: Text('No absences', style: TextStyle(color: colors.mutedForeground)),
+                ),
+              )
+            else
+              for (final a in absences)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: FTile(
+                    prefix: const Icon(FIcons.calendarOff),
+                    title: Text(a.reason?.isNotEmpty == true ? a.reason! : 'Absence'),
+                    subtitle: Text(_rangeLabel(a.from, a.until)),
+                    suffix: _TypeBadge(a.type),
+                    onPress: () => _openForm(context, existing: a),
+                  ),
+                ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openForm(BuildContext context, {AbsenceDto? existing}) async {
+    final changed = await showFSheet<bool>(
+      context: context,
+      side: FLayout.btt,
+      mainAxisMaxRatio: null,
+      builder: (_) => _AbsenceForm(existing: existing),
+    );
+    if (changed == true) await SchoolDataService.instance.refresh();
+  }
+
+  static String _rangeLabel(DateTime from, DateTime until) {
+    String d(DateTime x) => '${x.day}.${x.month}.${x.year}';
+    final f = d(from);
+    return until.difference(from).inDays.abs() < 1 ? f : '$f – ${d(until)}';
+  }
+}
+
+class _Stat extends StatelessWidget {
+  final String label;
+  final String value;
+  const _Stat({required this.label, required this.value});
+  @override
+  Widget build(BuildContext context) {
+    final t = context.theme.typography;
+    final c = context.theme.colors;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(value, style: t.xl2.copyWith(fontWeight: FontWeight.w700)),
+        Text(label, style: t.sm.copyWith(color: c.mutedForeground)),
+      ],
+    );
+  }
+}
+
+class _TypeBadge extends StatelessWidget {
+  final AbsenceType? type;
+  const _TypeBadge(this.type);
+  @override
+  Widget build(BuildContext context) {
+    final isDelay = type == AbsenceType.delay;
+    final color = isDelay ? const Color(0xFFF59E0B) : const Color(0xFFEF4444);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.16),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(isDelay ? 'Delay' : 'Absence',
+          style: TextStyle(color: color, fontWeight: FontWeight.w600, fontSize: 12)),
+    );
+  }
+}
+
+/// Bottom-sheet form to create or edit an absence.
+class _AbsenceForm extends StatefulWidget {
+  final AbsenceDto? existing;
+  const _AbsenceForm({this.existing});
+  @override
+  State<_AbsenceForm> createState() => _AbsenceFormState();
+}
+
+class _AbsenceFormState extends State<_AbsenceForm> {
+  late final TextEditingController _reason;
+  late AbsenceType _type;
+  late DateTime _from;
+  late DateTime _until;
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    final e = widget.existing;
+    _reason = TextEditingController(text: e?.reason ?? '');
+    _type = e?.type ?? AbsenceType.absence;
+    _from = e?.from ?? DateTime.now();
+    _until = e?.until ?? DateTime.now();
+  }
+
+  @override
+  void dispose() {
+    _reason.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDate(bool isFrom) async {
+    final initial = isFrom ? _from : _until;
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: DateTime(initial.year - 1),
+      lastDate: DateTime(initial.year + 1),
+    );
+    if (picked != null) {
+      setState(() {
+        if (isFrom) {
+          _from = picked;
+          if (_until.isBefore(_from)) _until = _from;
+        } else {
+          _until = picked;
+        }
+      });
+    }
+  }
+
+  Future<void> _save() async {
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final api = ApiClient.instance.api.getAbsencesApi();
+      final existing = widget.existing;
+      if (existing == null) {
+        final schoolUserId = SchoolDataService.instance.me?.id;
+        await api.apiAbsencesPost(
+          createAbsenceCommand: CreateAbsenceCommand((b) => b
+            ..reason = _reason.text.trim()
+            ..type = _type
+            ..from = _from.toUtc()
+            ..until = _until.toUtc()
+            ..schoolUserId = schoolUserId),
+        );
+      } else {
+        await api.apiAbsencesPut(
+          updateAbsenceCommand: UpdateAbsenceCommand((b) => b
+            ..absenceId = existing.id
+            ..reason = _reason.text.trim()
+            ..type = _type
+            ..from = _from.toUtc()
+            ..until = _until.toUtc()
+            ..schoolUserId = existing.schoolUserId),
+        );
+      }
+      if (mounted) Navigator.of(context).pop(true);
+    } on DioException catch (e) {
+      setState(() => _error = 'HTTP ${e.response?.statusCode}: ${e.response?.data}');
+    } catch (e) {
+      setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _delete() async {
+    final existing = widget.existing;
+    if (existing?.id == null) return;
+    setState(() => _busy = true);
+    try {
+      await ApiClient.instance.api.getAbsencesApi().apiAbsencesIdDelete(id: existing!.id!);
+      if (mounted) Navigator.of(context).pop(true);
+    } on DioException catch (e) {
+      setState(() {
+        _busy = false;
+        _error = 'HTTP ${e.response?.statusCode}: ${e.response?.data}';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    String d(DateTime x) => '${x.day}.${x.month}.${x.year}';
+    return Container(
+      decoration: BoxDecoration(color: colors.background),
+      padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + MediaQuery.viewInsetsOf(context).bottom),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(widget.existing == null ? 'Report absence' : 'Edit absence',
+              style: context.theme.typography.lg.copyWith(fontWeight: FontWeight.w600)),
+          const SizedBox(height: 16),
+          FTextField(
+            control: FTextFieldControl.managed(controller: _reason),
+            label: const Text('Reason'),
+          ),
+          const SizedBox(height: 12),
+          SegmentedButton<AbsenceType>(
+            segments: const [
+              ButtonSegment(value: AbsenceType.absence, label: Text('Absence')),
+              ButtonSegment(value: AbsenceType.delay, label: Text('Delay')),
+            ],
+            selected: {_type},
+            onSelectionChanged: (s) => setState(() => _type = s.first),
+            showSelectedIcon: false,
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton.icon(
+                  icon: const Icon(FIcons.calendar, size: 16),
+                  onPressed: () => _pickDate(true),
+                  label: Text('From: ${d(_from)}'),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: OutlinedButton.icon(
+                  icon: const Icon(FIcons.calendar, size: 16),
+                  onPressed: () => _pickDate(false),
+                  label: Text('Until: ${d(_until)}'),
+                ),
+              ),
+            ],
+          ),
+          if (_error != null) ...[
+            const SizedBox(height: 12),
+            SelectableText(_error!, style: TextStyle(color: colors.destructive)),
+          ],
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              if (widget.existing != null) ...[
+                IconButton(
+                  onPressed: _busy ? null : _delete,
+                  icon: Icon(FIcons.trash2, color: colors.destructive),
+                ),
+                const SizedBox(width: 8),
+              ],
+              Expanded(
+                child: FButton(
+                  onPress: _busy ? null : _save,
+                  child: Text(_busy ? 'Saving…' : 'Save'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/account/account_page.dart
+++ b/lib/ui/account/account_page.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+import '../../services/api_client.dart';
+import '../../services/school_data_service.dart';
+
+/// Account tab — profile details, enrolled classes, app info, and the account
+/// switcher + sign out.
+class AccountPage extends StatefulWidget {
+  final String? pictureUrl;
+  final String? userName;
+  final VoidCallback onOpenSwitcher;
+  final VoidCallback onSignOut;
+  const AccountPage({
+    super.key,
+    required this.pictureUrl,
+    required this.userName,
+    required this.onOpenSwitcher,
+    required this.onSignOut,
+  });
+
+  @override
+  State<AccountPage> createState() => _AccountPageState();
+}
+
+class _AccountPageState extends State<AccountPage> {
+  String? _version;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadVersion();
+  }
+
+  Future<void> _loadVersion() async {
+    try {
+      final res = await ApiClient.instance.api.getAppApi().apiAppGet();
+      if (mounted) setState(() => _version = res.data?.version);
+    } catch (_) {/* non-critical */}
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    final me = SchoolDataService.instance.me;
+    final classes = me?.classes ?? const <UserClassDto>[];
+
+    String fmtDate(Date? d) => d == null ? '—' : '${d.day}.${d.month}.${d.year}';
+    final fullName = me == null
+        ? (widget.userName ?? '—')
+        : '${me.firstName ?? ''} ${me.lastName ?? ''}'.trim();
+    final initial = fullName.isNotEmpty ? fullName.characters.first.toUpperCase() : '?';
+    final fallback = Text(initial,
+        style: TextStyle(color: colors.mutedForeground, fontWeight: FontWeight.w600));
+    // Prefer the school provider's photo, fall back to the OIDC picture.
+    final providerPfp = me?.profilePictureUrl;
+    final avatarUrl = (providerPfp?.isNotEmpty ?? false) ? providerPfp : widget.pictureUrl;
+
+    return RefreshIndicator(
+      onRefresh: () async {
+        await SchoolDataService.instance.refresh();
+        await _loadVersion();
+      },
+      child: ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+      children: [
+        // Identity header
+        Row(
+          children: [
+            (avatarUrl == null || avatarUrl.isEmpty)
+                ? FAvatar.raw(size: 56, child: fallback)
+                : FAvatar(size: 56, image: NetworkImage(avatarUrl), fallback: fallback),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(fullName.isEmpty ? 'Account' : fullName,
+                      style: typography.lg.copyWith(fontWeight: FontWeight.w700)),
+                  if (me?.role != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: _Badge(_roleLabel(me!.role)),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 20),
+        _SectionLabel('Profile'),
+        _InfoTile(icon: FIcons.mail, label: 'Email', value: me?.email),
+        _InfoTile(icon: FIcons.phone, label: 'Phone', value: me?.phoneNumber),
+        _InfoTile(
+          icon: FIcons.mapPin,
+          label: 'Address',
+          value: [me?.street, [me?.zip, me?.city].where((s) => (s ?? '').isNotEmpty).join(' ')]
+              .where((s) => (s ?? '').isNotEmpty)
+              .join(', '),
+        ),
+        _InfoTile(icon: FIcons.cake, label: 'Birthday', value: fmtDate(me?.birthday)),
+        _InfoTile(icon: FIcons.logIn, label: 'Joined', value: fmtDate(me?.entryDate)),
+        const SizedBox(height: 20),
+        if (classes.isNotEmpty) ...[
+          _SectionLabel('My classes'),
+          for (final c in classes)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: FTile(
+                prefix: const Icon(FIcons.users),
+                title: Text(c.className ?? 'Class'),
+              ),
+            ),
+          const SizedBox(height: 12),
+        ],
+        _SectionLabel('App'),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: FTile(
+            prefix: const Icon(FIcons.repeat),
+            title: const Text('Switch account'),
+            onPress: widget.onOpenSwitcher,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: FTile(
+            prefix: const Icon(FIcons.info),
+            title: const Text('Version'),
+            suffix: Text(_version ?? '—', style: TextStyle(color: colors.mutedForeground)),
+          ),
+        ),
+        const SizedBox(height: 4),
+        FButton(
+          prefix: const Icon(FIcons.logOut),
+          onPress: widget.onSignOut,
+          child: const Text('Sign out'),
+        ),
+      ],
+      ),
+    );
+  }
+
+  static String _roleLabel(Roles? r) => switch (r) {
+        Roles.teacher => 'Teacher',
+        Roles.administrator => 'Administrator',
+        _ => 'Student',
+      };
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String text;
+  const _SectionLabel(this.text);
+  @override
+  Widget build(BuildContext context) {
+    final c = context.theme.colors;
+    final t = context.theme.typography;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, 8),
+      child: Text(text.toUpperCase(),
+          style: t.xs.copyWith(color: c.mutedForeground, fontWeight: FontWeight.w600, letterSpacing: 0.5)),
+    );
+  }
+}
+
+class _InfoTile extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String? value;
+  const _InfoTile({required this.icon, required this.label, required this.value});
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: FTile(
+          prefix: Icon(icon),
+          title: Text(label),
+          details: Text((value?.isNotEmpty ?? false) ? value! : '—'),
+        ),
+      );
+}
+
+class _Badge extends StatelessWidget {
+  final String text;
+  const _Badge(this.text);
+  @override
+  Widget build(BuildContext context) {
+    final c = context.theme.colors;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: c.secondary,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(text, style: TextStyle(color: c.secondaryForeground, fontWeight: FontWeight.w600, fontSize: 12)),
+    );
+  }
+}

--- a/lib/ui/core/grade_color.dart
+++ b/lib/ui/core/grade_color.dart
@@ -10,9 +10,40 @@ Color gradeColor(BuildContext context, num grade) {
   return colors.destructive;
 }
 
+/// A score is only a real grade when it's on the 1–6 scale. 0/null means the
+/// exam exists but isn't graded yet — excluded from averages and shown as "—".
+bool isGraded(num? score) => score != null && score > 0;
+
 String formatGrade(num grade) {
   final s = grade.toStringAsFixed(2);
   return s.endsWith('00')
       ? grade.toStringAsFixed(0)
       : (s.endsWith('0') ? grade.toStringAsFixed(1) : s);
+}
+
+/// Coloured grade chip. Ungraded (≤0) scores render as a muted "—".
+class GradePill extends StatelessWidget {
+  final num? score;
+  const GradePill(this.score, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    if (!isGraded(score)) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: colors.muted,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text('—', style: TextStyle(color: colors.mutedForeground, fontWeight: FontWeight.w700)),
+      );
+    }
+    final c = gradeColor(context, score!);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(color: c.withValues(alpha: 0.18), borderRadius: BorderRadius.circular(8)),
+      child: Text(formatGrade(score!), style: TextStyle(color: c, fontWeight: FontWeight.w700)),
+    );
+  }
 }

--- a/lib/ui/dashboard/dashboard_screen.dart
+++ b/lib/ui/dashboard/dashboard_screen.dart
@@ -5,8 +5,11 @@ import 'package:forui/forui.dart';
 import '../../services/active_account_service.dart';
 import '../../services/auth_service.dart';
 import '../../services/school_data_service.dart';
+import '../absences/absences_page.dart';
+import '../account/account_page.dart';
 import '../grades/grades_page.dart';
 import '../home/home_page.dart';
+import '../timetable/timetable_page.dart';
 import 'widgets/accounts_sidebar.dart';
 import 'widgets/add_school_modal.dart';
 
@@ -44,6 +47,9 @@ class _DashboardScreenState extends State<DashboardScreen> {
     final id = ActiveAccountService.instance.active?.id;
     if (id != _lastSchoolId) {
       _lastSchoolId = id;
+      // Drop the previous school's cached data so we don't show stale content
+      // during the switch, then load the new school.
+      SchoolDataService.instance.clear();
       SchoolDataService.instance.refresh();
     }
   }
@@ -103,12 +109,17 @@ class _DashboardScreenState extends State<DashboardScreen> {
         final data = SchoolDataService.instance;
         final active = account.active;
 
-        final pages = const [
-          HomePage(),
-          _Placeholder(label: 'Timetable'),
-          GradesPage(),
-          _Placeholder(label: 'Absences'),
-          _Placeholder(label: 'Account'),
+        final pages = [
+          const HomePage(),
+          const TimetablePage(),
+          const GradesPage(),
+          const AbsencesPage(),
+          AccountPage(
+            pictureUrl: _pictureUrl,
+            userName: _userName,
+            onOpenSwitcher: _openSidebar,
+            onSignOut: widget.onSignOut,
+          ),
         ];
 
         Widget body;
@@ -132,7 +143,6 @@ class _DashboardScreenState extends State<DashboardScreen> {
             subtitle: active?.fullName,
             pictureUrl: _pictureUrl,
             userName: _userName,
-            loading: data.loading,
             onAvatar: _openSidebar,
           ),
           footer: SafeArea(
@@ -166,14 +176,12 @@ class _TopBar extends StatelessWidget {
   final String? subtitle;
   final String? pictureUrl;
   final String? userName;
-  final bool loading;
   final VoidCallback onAvatar;
   const _TopBar({
     required this.title,
     required this.subtitle,
     required this.pictureUrl,
     required this.userName,
-    required this.loading,
     required this.onAvatar,
   });
 
@@ -215,11 +223,6 @@ class _TopBar extends StatelessWidget {
                     ],
                   ),
                 ),
-                if (loading)
-                  const Padding(
-                    padding: EdgeInsets.only(left: 8),
-                    child: SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2)),
-                  ),
               ],
             ),
           ),
@@ -229,14 +232,4 @@ class _TopBar extends StatelessWidget {
       ),
     );
   }
-}
-
-class _Placeholder extends StatelessWidget {
-  final String label;
-  const _Placeholder({required this.label});
-  @override
-  Widget build(BuildContext context) => Center(
-        child: Text('$label — coming soon',
-            style: TextStyle(color: context.theme.colors.mutedForeground)),
-      );
 }

--- a/lib/ui/dashboard/widgets/accounts_sidebar.dart
+++ b/lib/ui/dashboard/widgets/accounts_sidebar.dart
@@ -96,7 +96,7 @@ class AccountsSidebar extends StatelessWidget {
                     children: [
                       for (final s in svc.schools)
                         FTile(
-                          prefix: const _SchoolAvatar(),
+                          prefix: _SchoolAvatar(asset: s.logoAsset),
                           title: Text(s.name),
                           subtitle: (s.fullName?.isNotEmpty ?? false)
                               ? Text(s.fullName!)
@@ -155,8 +155,8 @@ class AccountsSidebar extends StatelessWidget {
 /// once other providers exist this should pick the asset by provider.
 class _SchoolAvatar extends StatelessWidget {
   static const double size = 40;
-  static const _providerAsset = 'assets/schoolsystems/schulnetz.webp';
-  const _SchoolAvatar();
+  final String asset;
+  const _SchoolAvatar({required this.asset});
 
   @override
   Widget build(BuildContext context) {
@@ -169,7 +169,7 @@ class _SchoolAvatar extends StatelessWidget {
         borderRadius: BorderRadius.circular(10),
       ),
       padding: const EdgeInsets.all(7),
-      child: Image.asset(_providerAsset, fit: BoxFit.contain),
+      child: Image.asset(asset, fit: BoxFit.contain),
     );
   }
 }

--- a/lib/ui/dashboard/widgets/add_school_modal.dart
+++ b/lib/ui/dashboard/widgets/add_school_modal.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
+import '../../odaorg/connect_odaorg_screen.dart';
 import '../../schulnetz/connect_account_screen.dart';
 
 /// A school system the user can connect. Today only Schulnetz; the modal is
@@ -31,7 +32,6 @@ const _systems = <SchoolSystem>[
     id: 'odaorg',
     label: 'OdAOrg',
     assetPath: 'assets/schoolsystems/odaorg.webp',
-    enabled: false,
   ),
 ];
 
@@ -46,10 +46,13 @@ Future<String?> runAddSchoolFlow(
 ) async {
   final system = await showAddSchoolModal(context);
   if (system == null) return null;
-  // Only Schulnetz is wired today; future systems would branch on `system`.
-  return navigator.push<String>(
-    MaterialPageRoute(builder: (_) => const ConnectAccountScreen()),
-  );
+  // Each provider has its own connect screen — Schulnetz uses OAuth (WebView),
+  // OdAOrg uses username/password.
+  final Widget screen = switch (system) {
+    'odaorg' => const ConnectOdaOrgScreen(),
+    _ => const ConnectAccountScreen(),
+  };
+  return navigator.push<String>(MaterialPageRoute(builder: (_) => screen));
 }
 
 /// Shows the school-system picker. Resolves to the chosen [SchoolSystem.id]

--- a/lib/ui/grades/grades_page.dart
+++ b/lib/ui/grades/grades_page.dart
@@ -30,13 +30,14 @@ class GradesPage extends StatelessWidget {
       ...svc.classNameById,
     };
 
-    // Overall weighted average across all graded exams.
+    // Overall weighted average — only real (graded) scores count.
     double weightSum = 0, scoreSum = 0;
     for (final entry in myGrades.entries) {
       final g = entry.value;
+      if (!isGraded(g.score)) continue;
       final w = (g.weighting ?? 1).toDouble();
       weightSum += w;
-      scoreSum += (g.score ?? 0).toDouble() * w;
+      scoreSum += g.score!.toDouble() * w;
     }
     final overall = weightSum > 0 ? scoreSum / weightSum : null;
 
@@ -110,10 +111,10 @@ class _ClassSection extends StatelessWidget {
     double ws = 0, ss = 0;
     for (final e in exams) {
       final g = myGrades[e.id];
-      if (g == null) continue;
+      if (g == null || !isGraded(g.score)) continue;
       final w = (g.weighting ?? 1).toDouble();
       ws += w;
-      ss += (g.score ?? 0).toDouble() * w;
+      ss += g.score!.toDouble() * w;
     }
     final avg = ws > 0 ? ss / ws : null;
 
@@ -142,7 +143,7 @@ class _ClassSection extends StatelessWidget {
                 if ((myGrades[e.id]?.weighting ?? 1) != 1) 'weight ${formatGrade(myGrades[e.id]!.weighting ?? 1)}',
                 'class ⌀ ${formatGrade(e.classAverage)}',
               ].join(' · ')),
-              suffix: _GradePill(myGrades[e.id]?.score ?? 0),
+              suffix: GradePill(myGrades[e.id]?.score),
             ),
           ),
       ],
@@ -150,16 +151,3 @@ class _ClassSection extends StatelessWidget {
   }
 }
 
-class _GradePill extends StatelessWidget {
-  final num score;
-  const _GradePill(this.score);
-  @override
-  Widget build(BuildContext context) {
-    final c = gradeColor(context, score);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-      decoration: BoxDecoration(color: c.withValues(alpha: 0.18), borderRadius: BorderRadius.circular(8)),
-      child: Text(formatGrade(score), style: TextStyle(color: c, fontWeight: FontWeight.w700)),
-    );
-  }
-}

--- a/lib/ui/home/home_page.dart
+++ b/lib/ui/home/home_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
-import 'package:schuly_api/schuly_api.dart';
 
 import '../../services/school_data_service.dart';
 import '../core/grade_color.dart';
@@ -17,23 +16,23 @@ class HomePage extends StatelessWidget {
     final today = DateTime(now.year, now.month, now.day);
 
     bool sameDay(DateTime d) => d.year == today.year && d.month == today.month && d.day == today.day;
+    DateTime dayOf(DateTime d) => DateTime(d.year, d.month, d.day);
 
-    final todayLessons = svc.agenda
-        .where((a) => a.entryType == AgendaEntryType.lesson && sameDay(a.date))
-        .toList()
+    final todayEntries = svc.agenda.where((a) => sameDay(a.date)).toList()
       ..sort((a, b) => a.date.compareTo(b.date));
 
-    final upcomingTests = svc.agenda.where((a) {
-      final d = a.date;
-      return a.entryType == AgendaEntryType.test &&
-          !d.isBefore(today) &&
-          d.isBefore(today.add(const Duration(days: 7)));
-    }).toList()
+    final upcoming = svc.agenda.where((a) => dayOf(a.date).isAfter(today)).toList()
       ..sort((a, b) => a.date.compareTo(b.date));
 
     final myGrades = svc.myGradesByExam;
     final examName = {for (final e in svc.exams) e.id: e.name};
-    final recentGrades = myGrades.entries.toList().reversed.take(5).toList();
+    // Only real grades on the latest-grades card (drop ungraded 0 placeholders).
+    final recentGrades = myGrades.entries
+        .where((e) => isGraded(e.value.score))
+        .toList()
+        .reversed
+        .take(5)
+        .toList();
 
     final recentAbsences = svc.absences.toList()
       ..sort((a, b) => b.from.compareTo(a.from));
@@ -46,26 +45,26 @@ class HomePage extends StatelessWidget {
       children: [
         _Section(
           title: 'Today',
-          emptyText: 'No lessons today',
+          emptyText: 'Nothing scheduled today',
           tiles: [
-            for (final l in todayLessons)
+            for (final l in todayEntries)
               FTile(
-                prefix: const Icon(FIcons.bookOpen),
-                title: Text(l.title ?? 'Lesson'),
-                subtitle: Text([_time(l.date), l.place].whereType<String>().join(' · ')),
+                prefix: const Icon(FIcons.calendarDays),
+                title: Text(l.title?.isNotEmpty == true ? l.title! : 'Entry'),
+                subtitle: Text([_time(l.date), l.place].whereType<String>().where((s) => s.isNotEmpty).join(' · ')),
               ),
           ],
         ),
         const SizedBox(height: 16),
         _Section(
-          title: 'Upcoming tests',
-          emptyText: 'Nothing in the next 7 days',
+          title: 'Upcoming',
+          emptyText: 'Nothing upcoming',
           tiles: [
-            for (final t in upcomingTests)
+            for (final t in upcoming.take(5))
               FTile(
-                prefix: const Icon(FIcons.clipboardList),
-                title: Text(t.title ?? 'Test'),
-                subtitle: Text(_dateLabel(t.date)),
+                prefix: const Icon(FIcons.calendarDays),
+                title: Text(t.title?.isNotEmpty == true ? t.title! : 'Entry'),
+                subtitle: Text('${_dateLabel(t.date)} · ${_time(t.date)}'),
               ),
           ],
         ),
@@ -77,7 +76,7 @@ class HomePage extends StatelessWidget {
             for (final entry in recentGrades)
               FTile(
                 title: Text(examName[entry.key] ?? 'Exam'),
-                suffix: _GradePill(entry.value.score ?? 0),
+                suffix: GradePill(entry.value.score),
               ),
           ],
         ),
@@ -145,20 +144,6 @@ class _Section extends StatelessWidget {
           for (final t in tiles)
             Padding(padding: const EdgeInsets.only(bottom: 8), child: t),
       ],
-    );
-  }
-}
-
-class _GradePill extends StatelessWidget {
-  final num score;
-  const _GradePill(this.score);
-  @override
-  Widget build(BuildContext context) {
-    final c = gradeColor(context, score);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-      decoration: BoxDecoration(color: c.withValues(alpha: 0.18), borderRadius: BorderRadius.circular(8)),
-      child: Text(formatGrade(score), style: TextStyle(color: c, fontWeight: FontWeight.w700)),
     );
   }
 }

--- a/lib/ui/odaorg/connect_odaorg_screen.dart
+++ b/lib/ui/odaorg/connect_odaorg_screen.dart
@@ -1,0 +1,125 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+import '../../services/api_client.dart';
+
+/// Connects an OdaOrg account. Unlike Schulnetz (OAuth/WebView), OdaOrg uses
+/// plain username/password credentials posted to the backend, which then runs
+/// the initial sync. Pops with the new account id (String) on success.
+class ConnectOdaOrgScreen extends StatefulWidget {
+  const ConnectOdaOrgScreen({super.key});
+
+  @override
+  State<ConnectOdaOrgScreen> createState() => _ConnectOdaOrgScreenState();
+}
+
+class _ConnectOdaOrgScreenState extends State<ConnectOdaOrgScreen> {
+  final _userCtrl = TextEditingController();
+  final _passCtrl = TextEditingController();
+  final _urlCtrl = TextEditingController(text: 'https://www.oda.org');
+  final _nameCtrl = TextEditingController(text: 'OdAOrg');
+  bool _busy = false;
+  String? _error;
+
+  SchulyApi get _api => ApiClient.instance.api;
+
+  @override
+  void dispose() {
+    _userCtrl.dispose();
+    _passCtrl.dispose();
+    _urlCtrl.dispose();
+    _nameCtrl.dispose();
+    super.dispose();
+  }
+
+  T _expectJson<T>(Response<void> response) {
+    final data = response.data as Object?;
+    if (data is! T) {
+      throw StateError('Expected ${T.toString()}, got ${data.runtimeType}: $data');
+    }
+    return data;
+  }
+
+  Future<void> _connect() async {
+    final user = _userCtrl.text.trim();
+    final pass = _passCtrl.text;
+    if (user.isEmpty || pass.isEmpty) {
+      setState(() => _error = 'Username and password are required');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final accountsApi = _api.getAccountsApi();
+      final create = await accountsApi.apiPluginsOdaorgAccountsPost(
+        connectOdaOrgRequest: ConnectOdaOrgRequest((b) => b
+          ..username = user
+          ..password = pass
+          ..baseUrl = _urlCtrl.text.trim()
+          ..displayName = _nameCtrl.text.trim()),
+      );
+      final accountId = _expectJson<Map<String, dynamic>>(create)['id'] as String;
+
+      // Kick off the initial sync so data lands before we return.
+      await _api.getSyncApi().apiPluginsOdaorgAccountsAccountIdSyncPost(accountId: accountId);
+
+      if (mounted) Navigator.of(context).pop(accountId);
+    } on DioException catch (e) {
+      final status = e.response?.statusCode;
+      final body = e.response?.data;
+      setState(() => _error = 'HTTP ${status ?? '?'}: $body');
+    } catch (e) {
+      setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    return FScaffold(
+      header: FHeader.nested(
+        title: const Text('Add OdAOrg Account'),
+        prefixes: [FHeaderAction.back(onPress: () => Navigator.of(context).pop())],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        spacing: 16,
+        children: [
+          FTextField(
+            control: FTextFieldControl.managed(controller: _userCtrl),
+            label: const Text('Username'),
+            hint: 'e.g. LRN26487',
+            autocorrect: false,
+          ),
+          FTextField(
+            control: FTextFieldControl.managed(controller: _passCtrl),
+            label: const Text('Password'),
+            obscureText: true,
+            autocorrect: false,
+          ),
+          FTextField(
+            control: FTextFieldControl.managed(controller: _urlCtrl),
+            label: const Text('Base URL'),
+            keyboardType: TextInputType.url,
+          ),
+          FTextField(
+            control: FTextFieldControl.managed(controller: _nameCtrl),
+            label: const Text('Display Name'),
+          ),
+          FButton(
+            onPress: _busy ? null : _connect,
+            child: Text(_busy ? 'Connecting…' : 'Connect'),
+          ),
+          if (_error != null)
+            SelectableText(_error!, style: TextStyle(color: colors.destructive)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/timetable/timetable_page.dart
+++ b/lib/ui/timetable/timetable_page.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+import '../../services/school_data_service.dart';
+
+/// Timetable: a horizontal day strip (FLineCalendar) and the selected day's
+/// agenda entries, colour-coded by type.
+class TimetablePage extends StatefulWidget {
+  const TimetablePage({super.key});
+
+  @override
+  State<TimetablePage> createState() => _TimetablePageState();
+}
+
+class _TimetablePageState extends State<TimetablePage> {
+  DateTime? _selected; // null until the user picks or we auto-anchor
+  bool _userPicked = false;
+
+  @override
+  void initState() {
+    super.initState();
+    SchoolDataService.instance.addListener(_autoAnchor);
+    _autoAnchor();
+  }
+
+  @override
+  void dispose() {
+    SchoolDataService.instance.removeListener(_autoAnchor);
+    super.dispose();
+  }
+
+  /// Once agenda data is available (it loads after this page mounts), anchor
+  /// the calendar on the nearest day with entries — unless the user already
+  /// picked a day.
+  void _autoAnchor() {
+    if (_userPicked || _selected != null) return;
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final day = _nearestEntryDay(SchoolDataService.instance.agenda, today);
+    if (day != null && mounted) setState(() => _selected = day);
+  }
+
+  static DateTime? _nearestEntryDay(List<dynamic> agenda, DateTime today) {
+    final days = <DateTime>{
+      for (final a in agenda) DateTime(a.date.year, a.date.month, a.date.day),
+    }.toList()
+      ..sort();
+    if (days.isEmpty) return null;
+    for (final d in days) {
+      if (!d.isBefore(today)) return d; // soonest upcoming (incl. today)
+    }
+    return days.last; // everything is in the past → most recent
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final svc = SchoolDataService.instance;
+    final now = DateTime.now();
+    final selected = _selected ?? DateTime(now.year, now.month, now.day);
+
+    bool sameDay(DateTime d) =>
+        d.year == selected.year && d.month == selected.month && d.day == selected.day;
+
+    final entries = svc.agenda.where((a) => sameDay(a.date)).toList()
+      ..sort((a, b) => a.date.compareTo(b.date));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: FLineCalendar(
+            // Remount once when the anchor is first set, so initialScroll
+            // jumps the strip to the day with data.
+            key: ValueKey(_selected != null),
+            start: DateTime(now.year - 1),
+            end: DateTime(now.year + 2),
+            today: now,
+            initialScroll: selected,
+            control: FLineCalendarControl.lifted(
+              date: selected,
+              onChange: (d) {
+                if (d != null) {
+                  setState(() {
+                    _userPicked = true;
+                    _selected = d;
+                  });
+                }
+              },
+            ),
+          ),
+        ),
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: svc.refresh,
+            child: entries.isEmpty
+                ? ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    children: [
+                      SizedBox(
+                        height: 320,
+                        child: Center(
+                          child: Text('Nothing scheduled',
+                              style: TextStyle(color: colors.mutedForeground)),
+                        ),
+                      ),
+                    ],
+                  )
+                : ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+                    children: [
+                      for (final e in entries)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: _EntryTile(entry: e),
+                        ),
+                    ],
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _EntryTile extends StatelessWidget {
+  final AgendaEntryDto entry;
+  const _EntryTile({required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, color, icon) = _typeMeta(context, entry.entryType);
+    final time = _timeRange(entry.date);
+    return FTile(
+      prefix: Icon(icon, color: color),
+      title: Text(entry.title?.isNotEmpty == true ? entry.title! : label),
+      subtitle: Text([time, entry.place].whereType<String>().where((s) => s.isNotEmpty).join(' · ')),
+      suffix: _TypeBadge(label: label, color: color),
+    );
+  }
+
+  static String _timeRange(DateTime d) {
+    final h = d.hour.toString().padLeft(2, '0');
+    final m = d.minute.toString().padLeft(2, '0');
+    return '$h:$m';
+  }
+
+  static (String, Color, IconData) _typeMeta(BuildContext context, AgendaEntryType? t) {
+    final colors = context.theme.colors;
+    switch (t) {
+      case AgendaEntryType.test:
+        return ('Test', const Color(0xFFEF4444), FIcons.clipboardList);
+      case AgendaEntryType.event:
+        return ('Event', const Color(0xFF22C55E), FIcons.calendarHeart);
+      case AgendaEntryType.holiday:
+        return ('Holiday', const Color(0xFFF59E0B), FIcons.treePalm);
+      case AgendaEntryType.lesson:
+      default:
+        return ('Lesson', colors.primary, FIcons.bookOpen);
+    }
+  }
+}
+
+class _TypeBadge extends StatelessWidget {
+  final String label;
+  final Color color;
+  const _TypeBadge({required this.label, required this.color});
+
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.16),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Text(label,
+            style: TextStyle(color: color, fontWeight: FontWeight.w600, fontSize: 12)),
+      );
+}


### PR DESCRIPTION
Closes #272

- Timetable: FLineCalendar that auto-anchors to the nearest day with entries; per-day agenda, colour-coded by type.
- Absences: stats, list with type badges, report/edit/delete form (POST/PUT/DELETE).
- Account: profile, classes, role badge, app version, switch-account, sign out; pull-to-refresh.
- OdaOrg provider wired into the add-school picker (username/password connect screen); provider inferred client-side so each account shows the correct logo.
- Agenda scoped by the user's classIds; switching accounts clears cached data.
- Grade 0 treated as ungraded (excluded from averages, shown as "—").
- Provider profilePictureUrl used on the profile when present.
- Pull-to-refresh across tabs; removed header loading spinner; spacing polish.