### PR TITLE
Real provider sync + exam detail

### DIFF
--- a/lib/config/oidc_config.dart
+++ b/lib/config/oidc_config.dart
@@ -11,9 +11,9 @@ class OidcConfig {
   static const redirectUri = 'schulytest://callback';
   static const callbackScheme = 'schulytest';
 
-  // Android emulator loopback to the host. Use the LAN IP
-  // (http://192.168.188.93:5033) for a physical device on the same network.
-  static const backendBaseUrl = 'http://10.0.2.2:5033';
+  // USB-tethered phone via `adb reverse tcp:5033 tcp:5033`. Use the LAN IP
+  // (http://192.168.188.93:5033) or `http://10.0.2.2:5033` (emulator) instead.
+  static const backendBaseUrl = 'http://localhost:5033';
 
   static const tokenEndpoint = '$authority/api/oidc/token';
   static const authorizationEndpoint = '$authority/authorize';

--- a/lib/domain/schulware_account.dart
+++ b/lib/domain/schulware_account.dart
@@ -10,6 +10,8 @@ class MySchool {
   final String? email;
   final String? fullName;
   final String provider; // 'schulnetz' | 'odaorg'
+  /// The plugin account id backing this school (for triggering a sync).
+  final String? pluginAccountId;
 
   const MySchool({
     required this.id,
@@ -17,14 +19,21 @@ class MySchool {
     this.email,
     this.fullName,
     this.provider = 'schulnetz',
+    this.pluginAccountId,
   });
 
-  factory MySchool.fromDto(MySchoolDto dto, {String provider = 'schulnetz'}) => MySchool(
+  factory MySchool.fromDto(
+    MySchoolDto dto, {
+    String provider = 'schulnetz',
+    String? pluginAccountId,
+  }) =>
+      MySchool(
         id: dto.id ?? '',
         name: (dto.name?.isNotEmpty ?? false) ? dto.name! : 'School',
         email: dto.email,
         fullName: dto.fullName,
         provider: provider,
+        pluginAccountId: pluginAccountId,
       );
 
   /// Asset for this provider's logo.

--- a/lib/services/active_account_service.dart
+++ b/lib/services/active_account_service.dart
@@ -43,13 +43,15 @@ class ActiveAccountService extends ChangeNotifier {
       final res = await api.getSchoolsApi().apiSchoolsMySchoolsGet();
       final data = res.data;
 
-      final providerBySchoolId = await _detectProviders();
+      final pluginBySchoolId = await _detectPluginAccounts();
       _schools = data == null
           ? const []
-          : data
-              .map((dto) => MySchool.fromDto(dto,
-                  provider: providerBySchoolId[dto.id] ?? 'schulnetz'))
-              .toList(growable: false);
+          : data.map((dto) {
+              final info = pluginBySchoolId[dto.id];
+              return MySchool.fromDto(dto,
+                  provider: info?.provider ?? 'schulnetz',
+                  pluginAccountId: info?.accountId);
+            }).toList(growable: false);
 
       // Keep the persisted active id only if it still resolves to a school.
       final prefs = await SharedPreferences.getInstance();
@@ -72,11 +74,11 @@ class ActiveAccountService extends ChangeNotifier {
     }
   }
 
-  /// Maps schoolId → provider by cross-referencing the OdaOrg plugin's
-  /// accounts (which expose `schoolUserId`) against the user's SchoolUsers.
-  /// Anything not owned by OdaOrg defaults to Schulnetz. Best-effort: returns
-  /// an empty map on any failure so the account list still loads.
-  Future<Map<String, String>> _detectProviders() async {
+  /// Maps schoolId → (provider, plugin account id) by cross-referencing each
+  /// plugin's accounts (which expose `schoolUserId` + `id`) against the user's
+  /// SchoolUsers. Best-effort: returns an empty map on any failure so the
+  /// account list still loads.
+  Future<Map<String, ({String provider, String accountId})>> _detectPluginAccounts() async {
     try {
       final api = ApiClient.instance.api;
       final me = await api.getAuthApi().apiAuthMeGet();
@@ -90,14 +92,22 @@ class ActiveAccountService extends ChangeNotifier {
           if (u.id != null && u.schoolId != null) u.id!: u.schoolId!,
       };
 
-      final odaRes = await api.getAccountsApi().apiPluginsOdaorgAccountsGet();
-      final odaAccounts = (odaRes.data as List<dynamic>?) ?? const [];
-      final out = <String, String>{};
-      for (final a in odaAccounts.cast<Map<String, dynamic>>()) {
-        final suId = a['schoolUserId'] as String?;
-        final schoolId = suId == null ? null : schoolIdByUser[suId];
-        if (schoolId != null) out[schoolId] = 'odaorg';
+      final out = <String, ({String provider, String accountId})>{};
+      void mapAccounts(List<dynamic> accounts, String provider) {
+        for (final a in accounts.cast<Map<String, dynamic>>()) {
+          final suId = a['schoolUserId'] as String?;
+          final accId = a['id'] as String?;
+          final schoolId = suId == null ? null : schoolIdByUser[suId];
+          if (schoolId != null && accId != null) {
+            out[schoolId] = (provider: provider, accountId: accId);
+          }
+        }
       }
+
+      final oda = await api.getAccountsApi().apiPluginsOdaorgAccountsGet();
+      mapAccounts((oda.data as List<dynamic>?) ?? const [], 'odaorg');
+      final schul = await api.getAccountsApi().apiPluginsSchulwareAccountsGet();
+      mapAccounts((schul.data as List<dynamic>?) ?? const [], 'schulnetz');
       return out;
     } catch (_) {
       return const {};

--- a/lib/ui/account/account_page.dart
+++ b/lib/ui/account/account_page.dart
@@ -1,8 +1,10 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 import 'package:schuly_api/schuly_api.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../services/active_account_service.dart';
 import '../../services/api_client.dart';
 import '../../services/school_data_service.dart';
 import '../classes/class_detail_screen.dart';
@@ -28,6 +30,8 @@ class AccountPage extends StatefulWidget {
 
 class _AccountPageState extends State<AccountPage> {
   String? _version;
+  bool _syncing = false;
+  String? _syncMsg;
 
   @override
   void initState() {
@@ -40,6 +44,38 @@ class _AccountPageState extends State<AccountPage> {
       final res = await ApiClient.instance.api.getAppApi().apiAppGet();
       if (mounted) setState(() => _version = res.data?.version);
     } catch (_) {/* non-critical */}
+  }
+
+  /// Triggers an actual provider re-fetch for the active account, then reloads
+  /// the local data. Unlike pull-to-refresh (which only re-reads the backend),
+  /// this pulls fresh data from Schulnetz / OdaOrg.
+  Future<void> _syncNow() async {
+    final active = ActiveAccountService.instance.active;
+    final accountId = active?.pluginAccountId;
+    if (accountId == null) {
+      setState(() => _syncMsg = 'No connected account to sync');
+      return;
+    }
+    setState(() {
+      _syncing = true;
+      _syncMsg = null;
+    });
+    try {
+      final sync = ApiClient.instance.api.getSyncApi();
+      if (active!.provider == 'odaorg') {
+        await sync.apiPluginsOdaorgAccountsAccountIdSyncPost(accountId: accountId);
+      } else {
+        await sync.apiPluginsSchulwareAccountsAccountIdSyncPost(accountId: accountId);
+      }
+      await SchoolDataService.instance.refresh();
+      if (mounted) setState(() => _syncMsg = 'Synced just now');
+    } on DioException catch (e) {
+      if (mounted) setState(() => _syncMsg = 'Sync failed (${e.response?.statusCode ?? 'network'})');
+    } catch (e) {
+      if (mounted) setState(() => _syncMsg = 'Sync failed');
+    } finally {
+      if (mounted) setState(() => _syncing = false);
+    }
   }
 
   @override
@@ -159,6 +195,20 @@ class _AccountPageState extends State<AccountPage> {
           const SizedBox(height: 12),
         ],
         _SectionLabel('App'),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: FTile(
+            prefix: _syncing
+                ? const SizedBox(
+                    width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2))
+                : const Icon(FIcons.refreshCw),
+            title: const Text('Sync now'),
+            subtitle: _syncMsg != null
+                ? Text(_syncMsg!)
+                : const Text('Fetch fresh data from the provider'),
+            onPress: _syncing ? null : _syncNow,
+          ),
+        ),
         Padding(
           padding: const EdgeInsets.only(bottom: 8),
           child: FTile(

--- a/lib/ui/grades/grades_page.dart
+++ b/lib/ui/grades/grades_page.dart
@@ -136,9 +136,87 @@ class _ClassSection extends StatelessWidget {
                 'class ⌀ ${formatGrade(e.classAverage)}',
               ].join(' · ')),
               suffix: GradePill(myGrades[e.id]?.score),
+              onPress: () => _showExamDetail(context, e, myGrades[e.id]),
             ),
           ),
       ],
+    );
+  }
+}
+
+void _showExamDetail(BuildContext context, ExamDto exam, GradeDto? grade) {
+  showFSheet<void>(
+    context: context,
+    side: FLayout.btt,
+    mainAxisMaxRatio: null,
+    builder: (sheetCtx) => _ExamDetailSheet(exam: exam, grade: grade),
+  );
+}
+
+class _ExamDetailSheet extends StatelessWidget {
+  final ExamDto exam;
+  final GradeDto? grade;
+  const _ExamDetailSheet({required this.exam, required this.grade});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    final score = grade?.score;
+    final classAvg = exam.classAverage;
+
+    Widget bar(String label, num? value) {
+      final v = value ?? 0;
+      final pct = (v / 6).clamp(0.0, 1.0);
+      final c = isGraded(value) ? gradeColor(context, v) : colors.muted;
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(label, style: typography.sm.copyWith(color: colors.mutedForeground)),
+              Text(isGraded(value) ? formatGrade(v) : '—',
+                  style: typography.sm.copyWith(fontWeight: FontWeight.w700, color: c)),
+            ],
+          ),
+          const SizedBox(height: 4),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(6),
+            child: LinearProgressIndicator(
+              value: pct,
+              minHeight: 8,
+              backgroundColor: colors.muted,
+              valueColor: AlwaysStoppedAnimation(c),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return Container(
+      decoration: BoxDecoration(color: colors.background),
+      padding: EdgeInsets.fromLTRB(20, 20, 20, 24 + MediaQuery.viewPaddingOf(context).bottom),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(exam.name ?? 'Exam', style: typography.lg.copyWith(fontWeight: FontWeight.w700)),
+          if ((exam.description?.isNotEmpty ?? false)) ...[
+            const SizedBox(height: 4),
+            Text(exam.description!, style: TextStyle(color: colors.mutedForeground)),
+          ],
+          const SizedBox(height: 20),
+          bar('Your score', score),
+          const SizedBox(height: 14),
+          bar('Class average', classAvg),
+          if ((grade?.weighting ?? 1) != 1) ...[
+            const SizedBox(height: 16),
+            Text('Weighting: ${formatGrade(grade!.weighting ?? 1)}',
+                style: typography.sm.copyWith(color: colors.mutedForeground)),
+          ],
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
Closes #276

- Account: Sync now triggers the real provider re-fetch (POST .../accounts/{id}/sync) for the active account, then reloads.
- ActiveAccountService maps each school to its (provider, plugin account id).
- Exam detail sheet: score vs class average bars + weighting.