### PR TITLE
Remove account + document viewer/download

### DIFF
--- a/lib/config/oidc_config.dart
+++ b/lib/config/oidc_config.dart
@@ -11,9 +11,10 @@ class OidcConfig {
   static const redirectUri = 'schulytest://callback';
   static const callbackScheme = 'schulytest';
 
-  // USB-tethered phone via `adb reverse tcp:5033 tcp:5033`. Use the LAN IP
-  // (http://192.168.188.93:5033) or `http://10.0.2.2:5033` (emulator) instead.
-  static const backendBaseUrl = 'http://localhost:5033';
+  // LAN address of the dev box (Wi-Fi, no cable needed). Use
+  // `http://localhost:5033` + `adb reverse tcp:5033 tcp:5033` for USB, or
+  // `http://10.0.2.2:5033` for the emulator.
+  static const backendBaseUrl = 'http://192.168.188.93:5033';
 
   static const tokenEndpoint = '$authority/api/oidc/token';
   static const authorizationEndpoint = '$authority/authorize';

--- a/lib/services/active_account_service.dart
+++ b/lib/services/active_account_service.dart
@@ -122,6 +122,26 @@ class ActiveAccountService extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Disconnects a connected school via its plugin's DELETE endpoint, then
+  /// reloads the account list (which reselects an active school).
+  Future<void> removeSchool(MySchool school) async {
+    final accountId = school.pluginAccountId;
+    if (accountId == null) return;
+    final accounts = ApiClient.instance.api.getAccountsApi();
+    if (school.provider == 'odaorg') {
+      await accounts.apiPluginsOdaorgAccountsAccountIdDelete(accountId: accountId);
+    } else {
+      await accounts.apiPluginsSchulwareAccountsAccountIdDelete(accountId: accountId);
+    }
+    // If we removed the active school, drop the selection so refresh picks a new one.
+    if (_activeId == school.id) {
+      _activeId = null;
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_activeIdKey);
+    }
+    await refresh();
+  }
+
   Future<void> clear() async {
     _schools = const [];
     _activeId = null;

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -59,6 +59,10 @@ class ApiClient {
   late final Dio _dio;
   late final SchulyApi api;
 
+  /// The configured Dio (auth + refresh interceptor, backend base URL) for
+  /// requests the typed client doesn't cover well — e.g. binary downloads.
+  Dio get dio => _dio;
+
   /// In-flight refresh, shared so concurrent 401s trigger a single token
   /// exchange instead of a stampede.
   Future<String?>? _refreshing;

--- a/lib/ui/account/account_page.dart
+++ b/lib/ui/account/account_page.dart
@@ -1,6 +1,10 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
+import 'package:open_filex/open_filex.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:schuly_api/schuly_api.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -33,6 +37,33 @@ class _AccountPageState extends State<AccountPage> {
   String? _version;
   bool _syncing = false;
   String? _syncMsg;
+  String? _downloadingId;
+
+  /// Downloads a document's bytes through the authed Dio and opens it with the
+  /// system viewer.
+  Future<void> _openDocument(StudentDocumentDto doc) async {
+    final id = doc.id;
+    if (id == null) return;
+    setState(() => _downloadingId = id);
+    try {
+      final res = await ApiClient.instance.dio.get<List<int>>(
+        '/api/documents/$id',
+        options: Options(responseType: ResponseType.bytes),
+      );
+      final dir = await getTemporaryDirectory();
+      final name = (doc.fileName?.isNotEmpty ?? false) ? doc.fileName! : 'document-$id';
+      final file = File('${dir.path}/$name');
+      await file.writeAsBytes(res.data ?? const []);
+      await OpenFilex.open(file.path);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Could not open document: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _downloadingId = null);
+    }
+  }
 
   @override
   void initState() {
@@ -185,12 +216,17 @@ class _AccountPageState extends State<AccountPage> {
             Padding(
               padding: const EdgeInsets.only(bottom: 8),
               child: FTile(
-                prefix: const Icon(FIcons.fileText),
+                prefix: _downloadingId == dDoc.id
+                    ? const SizedBox(
+                        width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2))
+                    : const Icon(FIcons.fileText),
                 title: Text(dDoc.title?.isNotEmpty == true ? dDoc.title! : (dDoc.fileName ?? 'Document')),
                 subtitle: Text([
                   dDoc.category,
                   if (dDoc.fileSizeBytes != null) _fmtSize(dDoc.fileSizeBytes!),
                 ].whereType<String>().where((s) => s.isNotEmpty).join(' · ')),
+                suffix: const Icon(FIcons.download),
+                onPress: _downloadingId == null ? () => _openDocument(dDoc) : null,
               ),
             ),
           const SizedBox(height: 12),

--- a/lib/ui/dashboard/widgets/accounts_sidebar.dart
+++ b/lib/ui/dashboard/widgets/accounts_sidebar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
+import '../../../domain/schulware_account.dart';
 import '../../../services/active_account_service.dart';
 import 'add_school_modal.dart';
 
@@ -29,6 +30,31 @@ class AccountsSidebar extends StatelessWidget {
     this.userEmail,
     this.pictureUrl,
   });
+
+  Future<void> _confirmRemove(BuildContext context, MySchool school) async {
+    final confirmed = await showFDialog<bool>(
+      context: context,
+      builder: (dCtx, style, animation) => FDialog(
+        animation: animation,
+        title: const Text('Disconnect school'),
+        body: Text('Remove ${school.name}? You can reconnect it later.'),
+        actions: [
+          FButton(
+            onPress: () => Navigator.of(dCtx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FButton(
+            onPress: () => Navigator.of(dCtx).pop(true),
+            child: const Text('Disconnect'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    try {
+      await ActiveAccountService.instance.removeSchool(school);
+    } catch (_) {/* keep the sheet open; list reflects whatever succeeded */}
+  }
 
   Future<void> _add(BuildContext context) async {
     final svc = ActiveAccountService.instance;
@@ -112,6 +138,7 @@ class AccountsSidebar extends StatelessWidget {
                               Navigator.of(context).maybePop();
                             }
                           },
+                          onLongPress: () => _confirmRemove(context, s),
                         ),
                     ],
                   ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -533,6 +533,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  open_filex:
+    dependency: "direct main"
+    description:
+      name: open_filex
+      sha256: "9976da61b6a72302cf3b1efbce259200cd40232643a467aac7370addf94d6900"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.0"
   package_config:
     dependency: transitive
     description:
@@ -550,7 +558,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,8 @@ dependencies:
   flutter_inappwebview: ^6.1.5
   forui: ^0.17.0
   forui_assets: ^0.17.1
+  path_provider: ^2.1.2
+  open_filex: ^4.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Closes #280

- Sidebar: long-press a school to disconnect (confirm -> provider DELETE), then reload + reselect.
- Account: tap a document to download (authed Dio) + open with system viewer (open_filex).
- Expose ApiClient.dio; add open_filex + path_provider.