### PR TITLE
Fixed generated API client build and removed committed dev IPs

### DIFF
--- a/lib/api/lib/src/model/app_dto.g.dart
+++ b/lib/api/lib/src/model/app_dto.g.dart
@@ -8,28 +8,28 @@ part of 'app_dto.dart';
 
 class _$AppDto extends AppDto {
   @override
-  final String? authority;
+  final String authority;
   @override
-  final String? clientId;
+  final String clientId;
   @override
-  final String? redirectUri;
+  final String redirectUri;
   @override
-  final String? postLogoutRedirectUri;
+  final String postLogoutRedirectUri;
   @override
-  final String? scope;
+  final String scope;
   @override
-  final String? version;
+  final String version;
 
   factory _$AppDto([void Function(AppDtoBuilder)? updates]) =>
       (AppDtoBuilder()..update(updates))._build();
 
   _$AppDto._({
-    this.authority,
-    this.clientId,
-    this.redirectUri,
-    this.postLogoutRedirectUri,
-    this.scope,
-    this.version,
+    required this.authority,
+    required this.clientId,
+    required this.redirectUri,
+    required this.postLogoutRedirectUri,
+    required this.scope,
+    required this.version,
   }) : super._();
   @override
   AppDto rebuild(void Function(AppDtoBuilder) updates) =>
@@ -139,12 +139,36 @@ class AppDtoBuilder implements Builder<AppDto, AppDtoBuilder> {
     final _$result =
         _$v ??
         _$AppDto._(
-          authority: authority,
-          clientId: clientId,
-          redirectUri: redirectUri,
-          postLogoutRedirectUri: postLogoutRedirectUri,
-          scope: scope,
-          version: version,
+          authority: BuiltValueNullFieldError.checkNotNull(
+            authority,
+            r'AppDto',
+            'authority',
+          ),
+          clientId: BuiltValueNullFieldError.checkNotNull(
+            clientId,
+            r'AppDto',
+            'clientId',
+          ),
+          redirectUri: BuiltValueNullFieldError.checkNotNull(
+            redirectUri,
+            r'AppDto',
+            'redirectUri',
+          ),
+          postLogoutRedirectUri: BuiltValueNullFieldError.checkNotNull(
+            postLogoutRedirectUri,
+            r'AppDto',
+            'postLogoutRedirectUri',
+          ),
+          scope: BuiltValueNullFieldError.checkNotNull(
+            scope,
+            r'AppDto',
+            'scope',
+          ),
+          version: BuiltValueNullFieldError.checkNotNull(
+            version,
+            r'AppDto',
+            'version',
+          ),
         );
     replace(_$result);
     return _$result;

--- a/lib/api/lib/src/model/application_user_dto.g.dart
+++ b/lib/api/lib/src/model/application_user_dto.g.dart
@@ -10,9 +10,9 @@ class _$ApplicationUserDto extends ApplicationUserDto {
   @override
   final String? id;
   @override
-  final String? externalId;
+  final String externalId;
   @override
-  final String? email;
+  final String email;
   @override
   final String? displayName;
   @override
@@ -30,8 +30,8 @@ class _$ApplicationUserDto extends ApplicationUserDto {
 
   _$ApplicationUserDto._({
     this.id,
-    this.externalId,
-    this.email,
+    required this.externalId,
+    required this.email,
     this.displayName,
     this.profilePictureUrl,
     this.createdAt,
@@ -170,8 +170,16 @@ class ApplicationUserDtoBuilder
           _$v ??
           _$ApplicationUserDto._(
             id: id,
-            externalId: externalId,
-            email: email,
+            externalId: BuiltValueNullFieldError.checkNotNull(
+              externalId,
+              r'ApplicationUserDto',
+              'externalId',
+            ),
+            email: BuiltValueNullFieldError.checkNotNull(
+              email,
+              r'ApplicationUserDto',
+              'email',
+            ),
             displayName: displayName,
             profilePictureUrl: profilePictureUrl,
             createdAt: createdAt,

--- a/lib/api/lib/src/model/create_application_user_command.g.dart
+++ b/lib/api/lib/src/model/create_application_user_command.g.dart
@@ -8,9 +8,9 @@ part of 'create_application_user_command.dart';
 
 class _$CreateApplicationUserCommand extends CreateApplicationUserCommand {
   @override
-  final String? externalId;
+  final String externalId;
   @override
-  final String? email;
+  final String email;
   @override
   final String? displayName;
 
@@ -19,8 +19,8 @@ class _$CreateApplicationUserCommand extends CreateApplicationUserCommand {
   ]) => (CreateApplicationUserCommandBuilder()..update(updates))._build();
 
   _$CreateApplicationUserCommand._({
-    this.externalId,
-    this.email,
+    required this.externalId,
+    required this.email,
     this.displayName,
   }) : super._();
   @override
@@ -113,8 +113,16 @@ class CreateApplicationUserCommandBuilder
     final _$result =
         _$v ??
         _$CreateApplicationUserCommand._(
-          externalId: externalId,
-          email: email,
+          externalId: BuiltValueNullFieldError.checkNotNull(
+            externalId,
+            r'CreateApplicationUserCommand',
+            'externalId',
+          ),
+          email: BuiltValueNullFieldError.checkNotNull(
+            email,
+            r'CreateApplicationUserCommand',
+            'email',
+          ),
           displayName: displayName,
         );
     replace(_$result);

--- a/lib/api/lib/src/model/create_class_command.g.dart
+++ b/lib/api/lib/src/model/create_class_command.g.dart
@@ -8,7 +8,7 @@ part of 'create_class_command.dart';
 
 class _$CreateClassCommand extends CreateClassCommand {
   @override
-  final String? name;
+  final String name;
   @override
   final String? description;
 
@@ -16,7 +16,7 @@ class _$CreateClassCommand extends CreateClassCommand {
     void Function(CreateClassCommandBuilder)? updates,
   ]) => (CreateClassCommandBuilder()..update(updates))._build();
 
-  _$CreateClassCommand._({this.name, this.description}) : super._();
+  _$CreateClassCommand._({required this.name, this.description}) : super._();
   @override
   CreateClassCommand rebuild(
     void Function(CreateClassCommandBuilder) updates,
@@ -93,7 +93,15 @@ class CreateClassCommandBuilder
 
   _$CreateClassCommand _build() {
     final _$result =
-        _$v ?? _$CreateClassCommand._(name: name, description: description);
+        _$v ??
+        _$CreateClassCommand._(
+          name: BuiltValueNullFieldError.checkNotNull(
+            name,
+            r'CreateClassCommand',
+            'name',
+          ),
+          description: description,
+        );
     replace(_$result);
     return _$result;
   }

--- a/lib/api/lib/src/model/create_school_command.g.dart
+++ b/lib/api/lib/src/model/create_school_command.g.dart
@@ -8,7 +8,7 @@ part of 'create_school_command.dart';
 
 class _$CreateSchoolCommand extends CreateSchoolCommand {
   @override
-  final String? name;
+  final String name;
   @override
   final String? description;
   @override
@@ -35,7 +35,7 @@ class _$CreateSchoolCommand extends CreateSchoolCommand {
   ]) => (CreateSchoolCommandBuilder()..update(updates))._build();
 
   _$CreateSchoolCommand._({
-    this.name,
+    required this.name,
     this.description,
     this.email,
     this.phoneNumber,
@@ -197,7 +197,11 @@ class CreateSchoolCommandBuilder
     final _$result =
         _$v ??
         _$CreateSchoolCommand._(
-          name: name,
+          name: BuiltValueNullFieldError.checkNotNull(
+            name,
+            r'CreateSchoolCommand',
+            'name',
+          ),
           description: description,
           email: email,
           phoneNumber: phoneNumber,

--- a/lib/api/lib/src/model/create_teacher_command.g.dart
+++ b/lib/api/lib/src/model/create_teacher_command.g.dart
@@ -8,13 +8,13 @@ part of 'create_teacher_command.dart';
 
 class _$CreateTeacherCommand extends CreateTeacherCommand {
   @override
-  final String? schoolId;
+  final String schoolId;
   @override
-  final String? firstName;
+  final String firstName;
   @override
-  final String? lastName;
+  final String lastName;
   @override
-  final String? code;
+  final String code;
   @override
   final String? email;
 
@@ -23,10 +23,10 @@ class _$CreateTeacherCommand extends CreateTeacherCommand {
   ]) => (CreateTeacherCommandBuilder()..update(updates))._build();
 
   _$CreateTeacherCommand._({
-    this.schoolId,
-    this.firstName,
-    this.lastName,
-    this.code,
+    required this.schoolId,
+    required this.firstName,
+    required this.lastName,
+    required this.code,
     this.email,
   }) : super._();
   @override
@@ -131,10 +131,26 @@ class CreateTeacherCommandBuilder
     final _$result =
         _$v ??
         _$CreateTeacherCommand._(
-          schoolId: schoolId,
-          firstName: firstName,
-          lastName: lastName,
-          code: code,
+          schoolId: BuiltValueNullFieldError.checkNotNull(
+            schoolId,
+            r'CreateTeacherCommand',
+            'schoolId',
+          ),
+          firstName: BuiltValueNullFieldError.checkNotNull(
+            firstName,
+            r'CreateTeacherCommand',
+            'firstName',
+          ),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+            lastName,
+            r'CreateTeacherCommand',
+            'lastName',
+          ),
+          code: BuiltValueNullFieldError.checkNotNull(
+            code,
+            r'CreateTeacherCommand',
+            'code',
+          ),
           email: email,
         );
     replace(_$result);

--- a/lib/api/lib/src/model/enrol_student_command.g.dart
+++ b/lib/api/lib/src/model/enrol_student_command.g.dart
@@ -8,15 +8,16 @@ part of 'enrol_student_command.dart';
 
 class _$EnrolStudentCommand extends EnrolStudentCommand {
   @override
-  final String? userId;
+  final String userId;
   @override
-  final String? classId;
+  final String classId;
 
   factory _$EnrolStudentCommand([
     void Function(EnrolStudentCommandBuilder)? updates,
   ]) => (EnrolStudentCommandBuilder()..update(updates))._build();
 
-  _$EnrolStudentCommand._({this.userId, this.classId}) : super._();
+  _$EnrolStudentCommand._({required this.userId, required this.classId})
+    : super._();
   @override
   EnrolStudentCommand rebuild(
     void Function(EnrolStudentCommandBuilder) updates,
@@ -93,7 +94,19 @@ class EnrolStudentCommandBuilder
 
   _$EnrolStudentCommand _build() {
     final _$result =
-        _$v ?? _$EnrolStudentCommand._(userId: userId, classId: classId);
+        _$v ??
+        _$EnrolStudentCommand._(
+          userId: BuiltValueNullFieldError.checkNotNull(
+            userId,
+            r'EnrolStudentCommand',
+            'userId',
+          ),
+          classId: BuiltValueNullFieldError.checkNotNull(
+            classId,
+            r'EnrolStudentCommand',
+            'classId',
+          ),
+        );
     replace(_$result);
     return _$result;
   }

--- a/lib/api/lib/src/model/my_school_dto.g.dart
+++ b/lib/api/lib/src/model/my_school_dto.g.dart
@@ -10,11 +10,11 @@ class _$MySchoolDto extends MySchoolDto {
   @override
   final String? id;
   @override
-  final String? name;
+  final String name;
   @override
-  final String? email;
+  final String email;
   @override
-  final String? fullName;
+  final String fullName;
   @override
   final String? logoUrl;
   @override
@@ -25,9 +25,9 @@ class _$MySchoolDto extends MySchoolDto {
 
   _$MySchoolDto._({
     this.id,
-    this.name,
-    this.email,
-    this.fullName,
+    required this.name,
+    required this.email,
+    required this.fullName,
     this.logoUrl,
     this.profilePictureUrl,
   }) : super._();
@@ -140,9 +140,21 @@ class MySchoolDtoBuilder implements Builder<MySchoolDto, MySchoolDtoBuilder> {
         _$v ??
         _$MySchoolDto._(
           id: id,
-          name: name,
-          email: email,
-          fullName: fullName,
+          name: BuiltValueNullFieldError.checkNotNull(
+            name,
+            r'MySchoolDto',
+            'name',
+          ),
+          email: BuiltValueNullFieldError.checkNotNull(
+            email,
+            r'MySchoolDto',
+            'email',
+          ),
+          fullName: BuiltValueNullFieldError.checkNotNull(
+            fullName,
+            r'MySchoolDto',
+            'fullName',
+          ),
           logoUrl: logoUrl,
           profilePictureUrl: profilePictureUrl,
         );

--- a/lib/api/lib/src/model/plugin_dto.g.dart
+++ b/lib/api/lib/src/model/plugin_dto.g.dart
@@ -8,14 +8,14 @@ part of 'plugin_dto.dart';
 
 class _$PluginDto extends PluginDto {
   @override
-  final String? name;
+  final String name;
   @override
-  final String? version;
+  final String version;
 
   factory _$PluginDto([void Function(PluginDtoBuilder)? updates]) =>
       (PluginDtoBuilder()..update(updates))._build();
 
-  _$PluginDto._({this.name, this.version}) : super._();
+  _$PluginDto._({required this.name, required this.version}) : super._();
   @override
   PluginDto rebuild(void Function(PluginDtoBuilder) updates) =>
       (toBuilder()..update(updates)).build();
@@ -86,7 +86,20 @@ class PluginDtoBuilder implements Builder<PluginDto, PluginDtoBuilder> {
   PluginDto build() => _build();
 
   _$PluginDto _build() {
-    final _$result = _$v ?? _$PluginDto._(name: name, version: version);
+    final _$result =
+        _$v ??
+        _$PluginDto._(
+          name: BuiltValueNullFieldError.checkNotNull(
+            name,
+            r'PluginDto',
+            'name',
+          ),
+          version: BuiltValueNullFieldError.checkNotNull(
+            version,
+            r'PluginDto',
+            'version',
+          ),
+        );
     replace(_$result);
     return _$result;
   }

--- a/lib/api/lib/src/model/school_dto.g.dart
+++ b/lib/api/lib/src/model/school_dto.g.dart
@@ -10,7 +10,7 @@ class _$SchoolDto extends SchoolDto {
   @override
   final String? id;
   @override
-  final String? name;
+  final String name;
   @override
   final String? description;
   @override
@@ -41,7 +41,7 @@ class _$SchoolDto extends SchoolDto {
 
   _$SchoolDto._({
     this.id,
-    this.name,
+    required this.name,
     this.description,
     this.email,
     this.phoneNumber,
@@ -227,7 +227,11 @@ class SchoolDtoBuilder implements Builder<SchoolDto, SchoolDtoBuilder> {
         _$v ??
         _$SchoolDto._(
           id: id,
-          name: name,
+          name: BuiltValueNullFieldError.checkNotNull(
+            name,
+            r'SchoolDto',
+            'name',
+          ),
           description: description,
           email: email,
           phoneNumber: phoneNumber,

--- a/lib/api/lib/src/model/teacher_dto.g.dart
+++ b/lib/api/lib/src/model/teacher_dto.g.dart
@@ -14,11 +14,11 @@ class _$TeacherDto extends TeacherDto {
   @override
   final String? schoolName;
   @override
-  final String? firstName;
+  final String firstName;
   @override
-  final String? lastName;
+  final String lastName;
   @override
-  final String? code;
+  final String code;
   @override
   final String? email;
 
@@ -29,9 +29,9 @@ class _$TeacherDto extends TeacherDto {
     this.id,
     this.schoolId,
     this.schoolName,
-    this.firstName,
-    this.lastName,
-    this.code,
+    required this.firstName,
+    required this.lastName,
+    required this.code,
     this.email,
   }) : super._();
   @override
@@ -152,9 +152,21 @@ class TeacherDtoBuilder implements Builder<TeacherDto, TeacherDtoBuilder> {
           id: id,
           schoolId: schoolId,
           schoolName: schoolName,
-          firstName: firstName,
-          lastName: lastName,
-          code: code,
+          firstName: BuiltValueNullFieldError.checkNotNull(
+            firstName,
+            r'TeacherDto',
+            'firstName',
+          ),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+            lastName,
+            r'TeacherDto',
+            'lastName',
+          ),
+          code: BuiltValueNullFieldError.checkNotNull(
+            code,
+            r'TeacherDto',
+            'code',
+          ),
           email: email,
         );
     replace(_$result);

--- a/lib/api/lib/src/model/update_application_user_command.g.dart
+++ b/lib/api/lib/src/model/update_application_user_command.g.dart
@@ -8,7 +8,7 @@ part of 'update_application_user_command.dart';
 
 class _$UpdateApplicationUserCommand extends UpdateApplicationUserCommand {
   @override
-  final String? applicationUserId;
+  final String applicationUserId;
   @override
   final String? displayName;
   @override
@@ -19,7 +19,7 @@ class _$UpdateApplicationUserCommand extends UpdateApplicationUserCommand {
   ]) => (UpdateApplicationUserCommandBuilder()..update(updates))._build();
 
   _$UpdateApplicationUserCommand._({
-    this.applicationUserId,
+    required this.applicationUserId,
     this.displayName,
     this.profilePictureUrl,
   }) : super._();
@@ -115,7 +115,11 @@ class UpdateApplicationUserCommandBuilder
     final _$result =
         _$v ??
         _$UpdateApplicationUserCommand._(
-          applicationUserId: applicationUserId,
+          applicationUserId: BuiltValueNullFieldError.checkNotNull(
+            applicationUserId,
+            r'UpdateApplicationUserCommand',
+            'applicationUserId',
+          ),
           displayName: displayName,
           profilePictureUrl: profilePictureUrl,
         );

--- a/lib/api/lib/src/model/update_class_command.g.dart
+++ b/lib/api/lib/src/model/update_class_command.g.dart
@@ -8,9 +8,9 @@ part of 'update_class_command.dart';
 
 class _$UpdateClassCommand extends UpdateClassCommand {
   @override
-  final String? classId;
+  final String classId;
   @override
-  final String? name;
+  final String name;
   @override
   final String? description;
 
@@ -18,8 +18,11 @@ class _$UpdateClassCommand extends UpdateClassCommand {
     void Function(UpdateClassCommandBuilder)? updates,
   ]) => (UpdateClassCommandBuilder()..update(updates))._build();
 
-  _$UpdateClassCommand._({this.classId, this.name, this.description})
-    : super._();
+  _$UpdateClassCommand._({
+    required this.classId,
+    required this.name,
+    this.description,
+  }) : super._();
   @override
   UpdateClassCommand rebuild(
     void Function(UpdateClassCommandBuilder) updates,
@@ -106,8 +109,16 @@ class UpdateClassCommandBuilder
     final _$result =
         _$v ??
         _$UpdateClassCommand._(
-          classId: classId,
-          name: name,
+          classId: BuiltValueNullFieldError.checkNotNull(
+            classId,
+            r'UpdateClassCommand',
+            'classId',
+          ),
+          name: BuiltValueNullFieldError.checkNotNull(
+            name,
+            r'UpdateClassCommand',
+            'name',
+          ),
           description: description,
         );
     replace(_$result);

--- a/lib/api/lib/src/model/update_school_command.g.dart
+++ b/lib/api/lib/src/model/update_school_command.g.dart
@@ -8,9 +8,9 @@ part of 'update_school_command.dart';
 
 class _$UpdateSchoolCommand extends UpdateSchoolCommand {
   @override
-  final String? id;
+  final String id;
   @override
-  final String? name;
+  final String name;
   @override
   final String? description;
   @override
@@ -37,8 +37,8 @@ class _$UpdateSchoolCommand extends UpdateSchoolCommand {
   ]) => (UpdateSchoolCommandBuilder()..update(updates))._build();
 
   _$UpdateSchoolCommand._({
-    this.id,
-    this.name,
+    required this.id,
+    required this.name,
     this.description,
     this.email,
     this.phoneNumber,
@@ -208,8 +208,16 @@ class UpdateSchoolCommandBuilder
     final _$result =
         _$v ??
         _$UpdateSchoolCommand._(
-          id: id,
-          name: name,
+          id: BuiltValueNullFieldError.checkNotNull(
+            id,
+            r'UpdateSchoolCommand',
+            'id',
+          ),
+          name: BuiltValueNullFieldError.checkNotNull(
+            name,
+            r'UpdateSchoolCommand',
+            'name',
+          ),
           description: description,
           email: email,
           phoneNumber: phoneNumber,

--- a/lib/api/lib/src/model/update_teacher_command.g.dart
+++ b/lib/api/lib/src/model/update_teacher_command.g.dart
@@ -8,7 +8,7 @@ part of 'update_teacher_command.dart';
 
 class _$UpdateTeacherCommand extends UpdateTeacherCommand {
   @override
-  final String? teacherId;
+  final String teacherId;
   @override
   final String? firstName;
   @override
@@ -23,7 +23,7 @@ class _$UpdateTeacherCommand extends UpdateTeacherCommand {
   ]) => (UpdateTeacherCommandBuilder()..update(updates))._build();
 
   _$UpdateTeacherCommand._({
-    this.teacherId,
+    required this.teacherId,
     this.firstName,
     this.lastName,
     this.code,
@@ -131,7 +131,11 @@ class UpdateTeacherCommandBuilder
     final _$result =
         _$v ??
         _$UpdateTeacherCommand._(
-          teacherId: teacherId,
+          teacherId: BuiltValueNullFieldError.checkNotNull(
+            teacherId,
+            r'UpdateTeacherCommand',
+            'teacherId',
+          ),
           firstName: firstName,
           lastName: lastName,
           code: code,

--- a/lib/api/lib/src/model/user_class_dto.g.dart
+++ b/lib/api/lib/src/model/user_class_dto.g.dart
@@ -10,12 +10,13 @@ class _$UserClassDto extends UserClassDto {
   @override
   final String classId;
   @override
-  final String? className;
+  final String className;
 
   factory _$UserClassDto([void Function(UserClassDtoBuilder)? updates]) =>
       (UserClassDtoBuilder()..update(updates))._build();
 
-  _$UserClassDto._({required this.classId, this.className}) : super._();
+  _$UserClassDto._({required this.classId, required this.className})
+    : super._();
   @override
   UserClassDto rebuild(void Function(UserClassDtoBuilder) updates) =>
       (toBuilder()..update(updates)).build();
@@ -97,7 +98,11 @@ class UserClassDtoBuilder
             r'UserClassDto',
             'classId',
           ),
-          className: className,
+          className: BuiltValueNullFieldError.checkNotNull(
+            className,
+            r'UserClassDto',
+            'className',
+          ),
         );
     replace(_$result);
     return _$result;

--- a/lib/config/oidc_config.dart
+++ b/lib/config/oidc_config.dart
@@ -11,10 +11,14 @@ class OidcConfig {
   static const redirectUri = 'schulytest://callback';
   static const callbackScheme = 'schulytest';
 
-  // LAN address of the dev box (Wi-Fi, no cable needed). Use
-  // `http://localhost:5033` + `adb reverse tcp:5033 tcp:5033` for USB, or
-  // `http://10.0.2.2:5033` for the emulator.
-  static const backendBaseUrl = 'http://192.168.188.93:5033';
+  // Backend base URL. Override per build — never hardcode a machine IP here:
+  //   flutter build apk --dart-define=BACKEND_BASE_URL=http://<dev-box-lan-ip>:5033
+  // Defaults to localhost: use `adb reverse tcp:5033 tcp:5033` over USB, or
+  // `http://10.0.2.2:5033` on the emulator.
+  static const backendBaseUrl = String.fromEnvironment(
+    'BACKEND_BASE_URL',
+    defaultValue: 'http://localhost:5033',
+  );
 
   static const tokenEndpoint = '$authority/api/oidc/token';
   static const authorizationEndpoint = '$authority/authorize';

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "build:ios": "flutter build ios --flavor prod --no-codesign",
     "install:dev": "flutter build apk --flavor dev --release && flutter install --flavor dev",
     "install:prod": "flutter build apk --flavor prod --release && flutter install --flavor prod",
-    "apigen": "bunx --bun @openapitools/openapi-generator-cli generate -i http://192.168.188.162:5033/openapi/v1.json -g dart-dio -o lib/api --additional-properties=pubName=schuly_api,pubLibrary=schuly_api && bun run apigen:patch && bun run apigen:build",
+    "apigen": "bunx --bun @openapitools/openapi-generator-cli generate -i http://localhost:5033/openapi/v1.json -g dart-dio -o lib/api --additional-properties=pubName=schuly_api,pubLibrary=schuly_api && bun run apigen:patch && bun run apigen:build",
     "apigen:local": "bunx --bun @openapitools/openapi-generator-cli generate -i http://localhost:5033/openapi/v1.json -g dart-dio -o lib/api --additional-properties=pubName=schuly_api,pubLibrary=schuly_api && bun run apigen:patch && bun run apigen:build",
     "apigen:patch": "bun -e \"const f='lib/api/pubspec.yaml';await Bun.write(f,(await Bun.file(f).text()).replace(/sdk: '>=2\\\\.18\\\\.0 <4\\\\.0\\\\.0'/,'sdk: ^3.10.0'))\"",
-    "apigen:build": "cd lib/api && dart pub get && dart run build_runner build",
+    "apigen:build": "cd lib/api && dart pub get && dart run build_runner build --delete-conflicting-outputs",
     "icons": "dart run flutter_launcher_icons",
     "clean": "flutter clean && flutter pub get"
   }


### PR DESCRIPTION
Fixed generated API client build and removed committed dev IPs

- Regenerated `lib/api` cleanly (stale `.g.dart` made the client uncompilable; missed because `flutter analyze` excludes `lib/api`).
- `apigen:build` now passes `--delete-conflicting-outputs` so regens can't leave stale generated files.
- `oidc_config.dart` `backendBaseUrl` and the `apigen` script no longer hardcode a dev LAN IP — use `--dart-define=BACKEND_BASE_URL=...` (default localhost).

Closes #286