### PR TITLE
Reverted the 2.8.0 release version bump

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <properties>
-    <version>2.8.0</version>
+    <version>1.0.0</version>
 </properties>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.8.0+1
+version: 1.0.0+1
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Reverted the 2.8.0 release version bump

The v2.8.0 release was published in error and has been deleted; this restores main to its pre-release version.