### PR TITLE
Document enforced workflow rules in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,18 @@
 
 Minimal Flutter app. UI built with [Forui](https://forui.dev) (`FTheme` + `F*` widgets).
 
+## Workflow rules (enforced)
+
+- Never work on `main`. Create an issue (labeled) → branch `feature/<issue#>_PascalCase`
+  or `fix/<issue#>_PascalCase` → PR (labeled) with `Closes #<issue>` → squash-merge +
+  delete branch.
+- Use CLI generators whenever one exists — `npx create-expo-app`, `npx expo install`,
+  `gh issue create`, `gh pr create`, etc.
+- No AI / Claude attribution in commits or PRs. Ever.
+- No test plans in PRs. PR body is **Summary** + `Closes #<issue>` only.
+- Commit subject: short imperative.
+- PR labels: `bug`, `enhancement`, `refactor`, `stale`.
+
 ## Tasks (preferred)
 
 All common workflows are wrapped as `package.json` scripts so they're invoked the

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,7 +12,7 @@ Minimal Flutter app. UI built with [Forui](https://forui.dev) (`FTheme` + `F*` w
 - No AI / Claude attribution in commits or PRs. Ever.
 - No test plans in PRs. PR body is **Summary** + `Closes #<issue>` only.
 - Commit subject: short imperative.
-- PR labels: `bug`, `enhancement`, `refactor`, `stale`.
+- PR labels: `bug`, `enhancement`, `feature`, `refactor`, `CI/CD`, `dependencies`, `documentation`.
 
 ## Tasks (preferred)
 


### PR DESCRIPTION
@
## Summary

Add the enforced contribution workflow to `.claude/CLAUDE.md`: never work on `main`; issue → labeled branch → labeled PR with `Closes #<issue>` → squash-merge + delete branch. Also documents the CLI-generator preference, the no-AI-attribution rule, the PR body format, commit subject style, and the PR label set.

Closes #300
@