### PR TITLE
Drive school-system picker from backend catalog

### DIFF
--- a/lib/domain/school_system.dart
+++ b/lib/domain/school_system.dart
@@ -1,0 +1,74 @@
+/// A login provider the backend advertises via `GET /api/app/school-systems`.
+/// The app renders the picker (and, later, the login form) from this instead of
+/// hardcoding the available systems.
+class SchoolSystem {
+  final String key;
+  final String displayName;
+  final String? logoUrl;
+  final String? schulwareApiBaseUrl;
+
+  /// How the app drives the login: `oauth-webview` or `credentials`.
+  final String loginMethod;
+  final bool enabled;
+  final int sortOrder;
+  final List<SchoolSystemLoginField> loginFields;
+
+  const SchoolSystem({
+    required this.key,
+    required this.displayName,
+    required this.loginMethod,
+    this.logoUrl,
+    this.schulwareApiBaseUrl,
+    this.enabled = true,
+    this.sortOrder = 0,
+    this.loginFields = const [],
+  });
+
+  factory SchoolSystem.fromJson(Map<String, dynamic> json) {
+    final fields = (json['loginFields'] as List<dynamic>? ?? [])
+        .map((e) => SchoolSystemLoginField.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return SchoolSystem(
+      key: json['key'] as String,
+      displayName: json['displayName'] as String,
+      logoUrl: json['logoUrl'] as String?,
+      schulwareApiBaseUrl: json['schulwareApiBaseUrl'] as String?,
+      loginMethod: json['loginMethod'] as String? ?? 'oauth-webview',
+      enabled: json['enabled'] as bool? ?? true,
+      sortOrder: json['sortOrder'] as int? ?? 0,
+      loginFields: fields,
+    );
+  }
+}
+
+/// One input the app renders on a system's login form.
+class SchoolSystemLoginField {
+  final String key;
+  final String label;
+
+  /// Input hint: `url`, `text` or `password`.
+  final String type;
+  final String? placeholder;
+  final String? defaultValue;
+  final bool required;
+
+  const SchoolSystemLoginField({
+    required this.key,
+    required this.label,
+    required this.type,
+    this.placeholder,
+    this.defaultValue,
+    this.required = true,
+  });
+
+  factory SchoolSystemLoginField.fromJson(Map<String, dynamic> json) {
+    return SchoolSystemLoginField(
+      key: json['key'] as String,
+      label: json['label'] as String,
+      type: json['type'] as String? ?? 'text',
+      placeholder: json['placeholder'] as String?,
+      defaultValue: json['defaultValue'] as String?,
+      required: json['required'] as bool? ?? true,
+    );
+  }
+}

--- a/lib/services/school_systems_service.dart
+++ b/lib/services/school_systems_service.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/foundation.dart';
+
+import '../domain/school_system.dart';
+import 'api_client.dart';
+
+/// Fetches the backend-served catalog of school systems (anonymous endpoint).
+/// The backend is the source of truth for which systems exist and how to log
+/// in; the app renders the picker from this list.
+class SchoolSystemsService {
+  /// Known systems used when the catalog can't be reached (offline / backend
+  /// down), so the add-school flow still works. Mirrors the backend seed.
+  static const List<SchoolSystem> fallback = [
+    SchoolSystem(
+      key: 'schulnetz',
+      displayName: 'Schulnetz',
+      loginMethod: 'oauth-webview',
+      sortOrder: 0,
+    ),
+    SchoolSystem(
+      key: 'odaorg',
+      displayName: 'OdAOrg',
+      loginMethod: 'credentials',
+      sortOrder: 1,
+    ),
+  ];
+
+  static Future<List<SchoolSystem>> fetch() async {
+    try {
+      final response =
+          await ApiClient.instance.dio.get<List<dynamic>>('/api/app/school-systems');
+      final data = response.data ?? const [];
+      final systems = data
+          .map((e) => SchoolSystem.fromJson(e as Map<String, dynamic>))
+          .where((s) => s.enabled)
+          .toList()
+        ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+      return systems.isEmpty ? fallback : systems;
+    } catch (e) {
+      debugPrint('SchoolSystemsService: falling back to bundled systems: $e');
+      return fallback;
+    }
+  }
+}

--- a/lib/ui/dashboard/widgets/add_school_modal.dart
+++ b/lib/ui/dashboard/widgets/add_school_modal.dart
@@ -1,63 +1,49 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
+import '../../../domain/school_system.dart';
+import '../../../services/school_systems_service.dart';
 import '../../odaorg/connect_odaorg_screen.dart';
 import '../../schulnetz/connect_account_screen.dart';
 
-/// A school system the user can connect. Today only Schulnetz; the modal is
-/// shaped as a list so additional providers slot in without UX churn.
-class SchoolSystem {
-  final String id;
-  final String label;
-  final String assetPath;
-  /// When false the card is rendered greyed out with a "coming soon" hint
-  /// and tapping is a no-op. Lets us advertise upcoming integrations without
-  /// wiring them.
-  final bool enabled;
-  const SchoolSystem({
-    required this.id,
-    required this.label,
-    required this.assetPath,
-    this.enabled = true,
-  });
-}
+/// Local logo assets keyed by school-system key. Backend-advertised systems we
+/// don't yet bundle an asset for fall back to a generic icon.
+const _systemAssets = <String, String>{
+  'schulnetz': 'assets/schoolsystems/schulnetz.webp',
+  'odaorg': 'assets/schoolsystems/odaorg.webp',
+};
 
-const _systems = <SchoolSystem>[
-  SchoolSystem(
-    id: 'schulnetz',
-    label: 'Schulnetz',
-    assetPath: 'assets/schoolsystems/schulnetz.webp',
-  ),
-  SchoolSystem(
-    id: 'odaorg',
-    label: 'OdAOrg',
-    assetPath: 'assets/schoolsystems/odaorg.webp',
-  ),
-];
-
-/// Full add-school flow: show the school-system picker, then run the chosen
-/// system's connect screen. Returns the new account id, or null if the user
-/// cancelled at any step. [navigator] is the navigator the connect screen is
-/// pushed onto — pass the dashboard's, not a sheet/dialog navigator that may
-/// be torn down mid-flow.
+/// Full add-school flow: fetch the backend's school-system catalog, show the
+/// picker, then run the chosen system's connect screen. Returns the new account
+/// id, or null if the user cancelled at any step. [navigator] is the navigator
+/// the connect screen is pushed onto — pass the dashboard's, not a sheet/dialog
+/// navigator that may be torn down mid-flow.
 Future<String?> runAddSchoolFlow(
   BuildContext context,
   NavigatorState navigator,
 ) async {
-  final system = await showAddSchoolModal(context);
-  if (system == null) return null;
-  // Each provider has its own connect screen — Schulnetz uses OAuth (WebView),
-  // OdAOrg uses username/password.
-  final Widget screen = switch (system) {
-    'odaorg' => const ConnectOdaOrgScreen(),
+  final systems = await SchoolSystemsService.fetch();
+  if (!context.mounted) return null;
+
+  final systemKey = await showAddSchoolModal(context, systems);
+  if (systemKey == null) return null;
+
+  final system = systems.firstWhere((s) => s.key == systemKey);
+  // Branch on how the system logs in: credentials (OdAOrg) uses a
+  // username/password screen, everything else uses the OAuth (WebView) flow.
+  final Widget screen = switch (system.loginMethod) {
+    'credentials' => const ConnectOdaOrgScreen(),
     _ => const ConnectAccountScreen(),
   };
   return navigator.push<String>(MaterialPageRoute(builder: (_) => screen));
 }
 
-/// Shows the school-system picker. Resolves to the chosen [SchoolSystem.id]
-/// or `null` if the user dismissed.
-Future<String?> showAddSchoolModal(BuildContext context) {
+/// Shows the school-system picker for [systems]. Resolves to the chosen
+/// [SchoolSystem.key] or `null` if the user dismissed.
+Future<String?> showAddSchoolModal(
+  BuildContext context,
+  List<SchoolSystem> systems,
+) {
   return showFDialog<String>(
     context: context,
     builder: (dialogCtx, style, animation) => FDialog(
@@ -68,10 +54,11 @@ Future<String?> showAddSchoolModal(BuildContext context) {
         runSpacing: 12,
         alignment: WrapAlignment.center,
         children: [
-          for (final s in _systems)
+          for (final s in systems)
             _SystemCard(
               system: s,
-              onTap: s.enabled ? () => Navigator.of(dialogCtx).pop(s.id) : null,
+              onTap:
+                  s.enabled ? () => Navigator.of(dialogCtx).pop(s.key) : null,
             ),
         ],
       ),
@@ -94,6 +81,7 @@ class _SystemCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.theme.colors;
     final disabled = onTap == null;
+    final asset = _systemAssets[system.key];
     return Opacity(
       opacity: disabled ? 0.5 : 1.0,
       child: SizedBox(
@@ -107,10 +95,13 @@ class _SystemCard extends StatelessWidget {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Image.asset(system.assetPath, width: 48, height: 48),
+                  if (asset != null)
+                    Image.asset(asset, width: 48, height: 48)
+                  else
+                    Icon(Icons.school, size: 48, color: colors.mutedForeground),
                   const SizedBox(height: 10),
                   Text(
-                    system.label,
+                    system.displayName,
                     textAlign: TextAlign.center,
                     style: const TextStyle(fontWeight: FontWeight.w600),
                   ),


### PR DESCRIPTION
## Summary

Drive the add-school picker from the backend's `GET /api/app/school-systems` catalog instead of a hardcoded list. Adds a `SchoolSystem` model and a small service (with the bundled systems as an offline fallback), and routes to the connect screen by `loginMethod`. Behaviour is unchanged for users; the list is now server-driven.

Closes #303