### PR TITLE
Render login form fields from backend descriptor

### DIFF
--- a/lib/ui/dashboard/widgets/add_school_modal.dart
+++ b/lib/ui/dashboard/widgets/add_school_modal.dart
@@ -32,8 +32,8 @@ Future<String?> runAddSchoolFlow(
   // Branch on how the system logs in: credentials (OdAOrg) uses a
   // username/password screen, everything else uses the OAuth (WebView) flow.
   final Widget screen = switch (system.loginMethod) {
-    'credentials' => const ConnectOdaOrgScreen(),
-    _ => const ConnectAccountScreen(),
+    'credentials' => ConnectOdaOrgScreen(system: system),
+    _ => ConnectAccountScreen(system: system),
   };
   return navigator.push<String>(MaterialPageRoute(builder: (_) => screen));
 }

--- a/lib/ui/odaorg/connect_odaorg_screen.dart
+++ b/lib/ui/odaorg/connect_odaorg_screen.dart
@@ -3,33 +3,40 @@ import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 import 'package:schuly_api/schuly_api.dart';
 
+import '../../domain/school_system.dart';
 import '../../services/api_client.dart';
+import '../widgets/dynamic_login_form.dart';
 
 /// Connects an OdaOrg account. Unlike Schulnetz (OAuth/WebView), OdaOrg uses
 /// plain username/password credentials posted to the backend, which then runs
-/// the initial sync. Pops with the new account id (String) on success.
+/// the initial sync. Pops with the new account id (String) on success. The
+/// login inputs are rendered from [system]'s backend-described `loginFields`.
 class ConnectOdaOrgScreen extends StatefulWidget {
-  const ConnectOdaOrgScreen({super.key});
+  final SchoolSystem system;
+  const ConnectOdaOrgScreen({required this.system, super.key});
 
   @override
   State<ConnectOdaOrgScreen> createState() => _ConnectOdaOrgScreenState();
 }
 
 class _ConnectOdaOrgScreenState extends State<ConnectOdaOrgScreen> {
-  final _userCtrl = TextEditingController();
-  final _passCtrl = TextEditingController();
-  final _urlCtrl = TextEditingController(text: 'https://www.oda.org');
-  final _nameCtrl = TextEditingController(text: 'OdAOrg');
+  late final DynamicLoginFormController _form;
+  late final TextEditingController _nameCtrl;
   bool _busy = false;
   String? _error;
 
   SchulyApi get _api => ApiClient.instance.api;
 
   @override
+  void initState() {
+    super.initState();
+    _form = DynamicLoginFormController(widget.system.loginFields);
+    _nameCtrl = TextEditingController(text: widget.system.displayName);
+  }
+
+  @override
   void dispose() {
-    _userCtrl.dispose();
-    _passCtrl.dispose();
-    _urlCtrl.dispose();
+    _form.dispose();
     _nameCtrl.dispose();
     super.dispose();
   }
@@ -43,10 +50,9 @@ class _ConnectOdaOrgScreenState extends State<ConnectOdaOrgScreen> {
   }
 
   Future<void> _connect() async {
-    final user = _userCtrl.text.trim();
-    final pass = _passCtrl.text;
-    if (user.isEmpty || pass.isEmpty) {
-      setState(() => _error = 'Username and password are required');
+    final missing = _form.validateRequired();
+    if (missing != null) {
+      setState(() => _error = missing);
       return;
     }
     setState(() {
@@ -57,9 +63,9 @@ class _ConnectOdaOrgScreenState extends State<ConnectOdaOrgScreen> {
       final accountsApi = _api.getAccountsApi();
       final create = await accountsApi.apiPluginsOdaorgAccountsPost(
         connectOdaOrgRequest: ConnectOdaOrgRequest((b) => b
-          ..username = user
-          ..password = pass
-          ..baseUrl = _urlCtrl.text.trim()
+          ..username = _form.value('username')
+          ..password = _form.value('password')
+          ..baseUrl = _form.value('baseUrl')
           ..displayName = _nameCtrl.text.trim()),
       );
       final accountId = _expectJson<Map<String, dynamic>>(create)['id'] as String;
@@ -84,30 +90,14 @@ class _ConnectOdaOrgScreenState extends State<ConnectOdaOrgScreen> {
     final colors = context.theme.colors;
     return FScaffold(
       header: FHeader.nested(
-        title: const Text('Add OdAOrg Account'),
+        title: Text('Add ${widget.system.displayName} Account'),
         prefixes: [FHeaderAction.back(onPress: () => Navigator.of(context).pop())],
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         spacing: 16,
         children: [
-          FTextField(
-            control: FTextFieldControl.managed(controller: _userCtrl),
-            label: const Text('Username'),
-            hint: 'e.g. LRN26487',
-            autocorrect: false,
-          ),
-          FTextField(
-            control: FTextFieldControl.managed(controller: _passCtrl),
-            label: const Text('Password'),
-            obscureText: true,
-            autocorrect: false,
-          ),
-          FTextField(
-            control: FTextFieldControl.managed(controller: _urlCtrl),
-            label: const Text('Base URL'),
-            keyboardType: TextInputType.url,
-          ),
+          DynamicLoginForm(controller: _form),
           FTextField(
             control: FTextFieldControl.managed(controller: _nameCtrl),
             label: const Text('Display Name'),

--- a/lib/ui/schulnetz/connect_account_screen.dart
+++ b/lib/ui/schulnetz/connect_account_screen.dart
@@ -2,31 +2,42 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 import 'package:schuly_api/schuly_api.dart';
+import '../../domain/school_system.dart';
 import '../../services/api_client.dart';
+import '../widgets/dynamic_login_form.dart';
 import 'schulnetz_oauth_screen.dart';
 
 /// Connects a Schulnetz school account on the backend.
 ///
 /// Pushed as its own route. Pops with the new account id (`String`) on success
-/// or `null` if the user cancels / a failure occurred.
+/// or `null` if the user cancels / a failure occurred. The login inputs are
+/// rendered from [system]'s backend-described `loginFields`.
 class ConnectAccountScreen extends StatefulWidget {
-  const ConnectAccountScreen({super.key});
+  final SchoolSystem system;
+  const ConnectAccountScreen({required this.system, super.key});
 
   @override
   State<ConnectAccountScreen> createState() => _ConnectAccountScreenState();
 }
 
 class _ConnectAccountScreenState extends State<ConnectAccountScreen> {
-  final _urlCtrl = TextEditingController(text: 'https://schulnetz.bbbaden.ch');
-  final _nameCtrl = TextEditingController(text: 'BBBaden');
+  late final DynamicLoginFormController _form;
+  late final TextEditingController _nameCtrl;
   bool _busy = false;
   String? _error;
 
   SchulyApi get _api => ApiClient.instance.api;
 
   @override
+  void initState() {
+    super.initState();
+    _form = DynamicLoginFormController(widget.system.loginFields);
+    _nameCtrl = TextEditingController(text: widget.system.displayName);
+  }
+
+  @override
   void dispose() {
-    _urlCtrl.dispose();
+    _form.dispose();
     _nameCtrl.dispose();
     super.dispose();
   }
@@ -40,12 +51,17 @@ class _ConnectAccountScreenState extends State<ConnectAccountScreen> {
   }
 
   Future<void> _create() async {
+    final missing = _form.validateRequired();
+    if (missing != null) {
+      setState(() => _error = missing);
+      return;
+    }
     setState(() {
       _busy = true;
       _error = null;
     });
     try {
-      final url = _urlCtrl.text.trim();
+      final url = _form.value('baseUrl');
       final accountsApi = _api.getAccountsApi();
       final oauthApi = _api.getOAuthApi();
       String? accountId;
@@ -130,7 +146,7 @@ class _ConnectAccountScreenState extends State<ConnectAccountScreen> {
     final colors = context.theme.colors;
     return FScaffold(
       header: FHeader.nested(
-        title: const Text('Add Schulnetz Account'),
+        title: Text('Add ${widget.system.displayName} Account'),
         prefixes: [
           FHeaderAction.back(
             onPress: () => Navigator.of(context).pop(),
@@ -141,12 +157,7 @@ class _ConnectAccountScreenState extends State<ConnectAccountScreen> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         spacing: 16,
         children: [
-          FTextField(
-            control: FTextFieldControl.managed(controller: _urlCtrl),
-            label: const Text('Schulnetz Base URL'),
-            hint: 'https://schulnetz.example.ch',
-            keyboardType: TextInputType.url,
-          ),
+          DynamicLoginForm(controller: _form),
           FTextField(
             control: FTextFieldControl.managed(controller: _nameCtrl),
             label: const Text('Display Name'),

--- a/lib/ui/widgets/dynamic_login_form.dart
+++ b/lib/ui/widgets/dynamic_login_form.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+
+import '../../domain/school_system.dart';
+
+/// Owns the text controllers for a set of backend-described login fields and
+/// exposes their collected values. The screen creates one from a system's
+/// [SchoolSystemLoginField]s and reads [values] on submit.
+class DynamicLoginFormController {
+  final List<SchoolSystemLoginField> fields;
+  final Map<String, TextEditingController> _controllers;
+
+  DynamicLoginFormController(this.fields)
+      : _controllers = {
+          for (final f in fields)
+            f.key: TextEditingController(text: f.defaultValue ?? ''),
+        };
+
+  TextEditingController controllerFor(String key) => _controllers[key]!;
+
+  /// Trimmed value for [key], or empty string if the field isn't present.
+  String value(String key) => _controllers[key]?.text.trim() ?? '';
+
+  /// Collected values keyed by field key.
+  Map<String, String> get values =>
+      {for (final f in fields) f.key: value(f.key)};
+
+  /// First missing required field as an error message, or null if all present.
+  String? validateRequired() {
+    for (final f in fields) {
+      if (f.required && value(f.key).isEmpty) {
+        return '${f.label} is required';
+      }
+    }
+    return null;
+  }
+
+  void dispose() {
+    for (final c in _controllers.values) {
+      c.dispose();
+    }
+  }
+}
+
+/// Renders the login inputs a school system advertises (`loginFields`) so the
+/// backend, not the app, decides what the login form shows.
+class DynamicLoginForm extends StatelessWidget {
+  final DynamicLoginFormController controller;
+  const DynamicLoginForm({required this.controller, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      spacing: 16,
+      children: [
+        for (final field in controller.fields)
+          FTextField(
+            control: FTextFieldControl.managed(
+              controller: controller.controllerFor(field.key),
+            ),
+            label: Text(field.label),
+            hint: field.placeholder,
+            obscureText: field.type == 'password',
+            keyboardType: field.type == 'url'
+                ? TextInputType.url
+                : TextInputType.text,
+            autocorrect: false,
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Render the Schulnetz and OdAOrg connect-screen inputs from each system's backend-described `loginFields` via a reusable `DynamicLoginForm`, so the backend decides which login inputs show. The account display name stays an app-side field; the provider-specific submit logic (OAuth WebView vs credentials) is unchanged.

Closes #305