### PR TITLE
Store OIDC tokens in secure storage

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:app_links/app_links.dart';
 import 'package:crypto/crypto.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -27,6 +28,36 @@ class AuthService {
   static const _kAccessTokenKey = 'auth.access_token';
   static const _kIdTokenKey = 'auth.id_token';
   static const _kRefreshTokenKey = 'auth.refresh_token';
+
+  /// OIDC tokens live in the platform keystore (Android EncryptedSharedPrefs /
+  /// iOS Keychain), not plaintext SharedPreferences.
+  static const _storage = FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
+
+  /// One-shot migration of tokens written by older builds into SharedPreferences.
+  /// Memoised so it runs at most once per process.
+  static Future<void>? _migration;
+  static Future<void> _ensureMigrated() => _migration ??= _migrate();
+
+  static Future<void> _migrate() async {
+    // Already in secure storage → nothing to carry over.
+    if (await _storage.containsKey(key: _kAccessTokenKey)) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final access = prefs.getString(_kAccessTokenKey);
+    if (access == null) return; // fresh install or already migrated + signed out
+
+    final idToken = prefs.getString(_kIdTokenKey);
+    final refresh = prefs.getString(_kRefreshTokenKey);
+    await _storage.write(key: _kAccessTokenKey, value: access);
+    if (idToken != null) await _storage.write(key: _kIdTokenKey, value: idToken);
+    if (refresh != null) await _storage.write(key: _kRefreshTokenKey, value: refresh);
+
+    await prefs.remove(_kAccessTokenKey);
+    await prefs.remove(_kIdTokenKey);
+    await prefs.remove(_kRefreshTokenKey);
+  }
 
   static final AppLinks _appLinks = AppLinks();
 
@@ -125,22 +156,24 @@ class AuthService {
   }
 
   static Future<void> _persist(AuthTokens tokens) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_kAccessTokenKey, tokens.accessToken);
-    if (tokens.idToken != null) await prefs.setString(_kIdTokenKey, tokens.idToken!);
+    await _ensureMigrated();
+    await _storage.write(key: _kAccessTokenKey, value: tokens.accessToken);
+    if (tokens.idToken != null) {
+      await _storage.write(key: _kIdTokenKey, value: tokens.idToken!);
+    }
     if (tokens.refreshToken != null) {
-      await prefs.setString(_kRefreshTokenKey, tokens.refreshToken!);
+      await _storage.write(key: _kRefreshTokenKey, value: tokens.refreshToken!);
     }
   }
 
   static Future<String?> getAccessToken() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getString(_kAccessTokenKey);
+    await _ensureMigrated();
+    return _storage.read(key: _kAccessTokenKey);
   }
 
   static Future<String?> getRefreshToken() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getString(_kRefreshTokenKey);
+    await _ensureMigrated();
+    return _storage.read(key: _kRefreshTokenKey);
   }
 
   /// Exchanges the stored refresh token for a fresh access token and persists
@@ -182,8 +215,8 @@ class AuthService {
   /// malformed. Pure local decode — no signature verification, which is fine
   /// since the token was already validated at exchange time.
   static Future<Map<String, dynamic>?> getIdTokenClaims() async {
-    final prefs = await SharedPreferences.getInstance();
-    final idToken = prefs.getString(_kIdTokenKey);
+    await _ensureMigrated();
+    final idToken = await _storage.read(key: _kIdTokenKey);
     if (idToken == null) return null;
     final parts = idToken.split('.');
     if (parts.length != 3) return null;
@@ -196,6 +229,10 @@ class AuthService {
   }
 
   static Future<void> signOut() async {
+    await _storage.delete(key: _kAccessTokenKey);
+    await _storage.delete(key: _kIdTokenKey);
+    await _storage.delete(key: _kRefreshTokenKey);
+    // Clear any tokens an older build may have left in SharedPreferences too.
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_kAccessTokenKey);
     await prefs.remove(_kIdTokenKey);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -307,6 +307,54 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -405,6 +453,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -449,26 +505,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -741,10 +797,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -849,6 +905,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   http: ^1.2.2
   crypto: ^3.0.5
   shared_preferences: ^2.3.2
+  flutter_secure_storage: ^9.2.2
   app_links: ^6.3.2
   flutter_inappwebview: ^6.1.5
   forui: ^0.17.0


### PR DESCRIPTION
## Summary

Move OIDC access/id/refresh tokens from plaintext SharedPreferences to `flutter_secure_storage` (Android EncryptedSharedPreferences / iOS Keychain). Includes a one-time migration of tokens written by older builds so users stay signed in across the upgrade, and sign-out clears both stores.

Closes #307