### PR TITLE
Suppress AI attribution in commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}


### PR DESCRIPTION
## Summary

Add `.claude/settings.json` with `attribution.commit` and `attribution.pr` set to empty strings, suppressing the Claude Code byline in commits and PRs repo-wide, per the no-attribution rule in `.claude/CLAUDE.md`. Force-added to mirror how `.claude/CLAUDE.md` is tracked despite the `.claude/` gitignore.

Closes #309