### PR TITLE
Fix analyze warnings (redundant null-aware / dead fallbacks)

### DIFF
--- a/lib/domain/schulware_account.dart
+++ b/lib/domain/schulware_account.dart
@@ -36,7 +36,7 @@ class MySchool {
   }) =>
       MySchool(
         id: dto.id ?? '',
-        name: (dto.name?.isNotEmpty ?? false) ? dto.name! : 'School',
+        name: dto.name.isNotEmpty ? dto.name : 'School',
         email: dto.email,
         fullName: dto.fullName,
         provider: provider,

--- a/lib/services/school_data_service.dart
+++ b/lib/services/school_data_service.dart
@@ -41,7 +41,7 @@ class SchoolDataService extends ChangeNotifier {
   Map<String, String> get classNameById {
     final out = <String, String>{};
     for (final c in _classes) {
-      if (c.id != null && (c.name?.isNotEmpty ?? false)) out[c.id!] = c.name!;
+      if (c.id != null && c.name.isNotEmpty) out[c.id!] = c.name;
     }
     return out;
   }

--- a/lib/ui/account/account_page.dart
+++ b/lib/ui/account/account_page.dart
@@ -123,7 +123,7 @@ class _AccountPageState extends State<AccountPage> {
     String fmtDate(Date? d) => d == null ? '—' : '${d.day}.${d.month}.${d.year}';
     final fullName = me == null
         ? (widget.userName ?? '—')
-        : '${me.firstName ?? ''} ${me.lastName ?? ''}'.trim();
+        : '${me.firstName} ${me.lastName}'.trim();
     final initial = fullName.isNotEmpty ? fullName.characters.first.toUpperCase() : '?';
     final fallback = Text(initial,
         style: TextStyle(color: colors.mutedForeground, fontWeight: FontWeight.w600));
@@ -184,12 +184,12 @@ class _AccountPageState extends State<AccountPage> {
               padding: const EdgeInsets.only(bottom: 8),
               child: FTile(
                 prefix: const Icon(FIcons.users),
-                title: Text(c.className ?? 'Class'),
+                title: Text(c.className),
                 suffix: const Icon(FIcons.chevronRight),
                 onPress: () => Navigator.of(context).push(MaterialPageRoute(
                   builder: (_) => ClassDetailScreen(
                     classId: c.classId,
-                    title: c.className ?? 'Class',
+                    title: c.className,
                   ),
                 )),
               ),
@@ -203,8 +203,8 @@ class _AccountPageState extends State<AccountPage> {
               padding: const EdgeInsets.only(bottom: 8),
               child: FTile(
                 prefix: const Icon(FIcons.user),
-                title: Text('${t.firstName ?? ''} ${t.lastName ?? ''}'.trim()),
-                subtitle: (t.code?.isNotEmpty ?? false) ? Text(t.code!) : null,
+                title: Text('${t.firstName} ${t.lastName}'.trim()),
+                subtitle: t.code.isNotEmpty ? Text(t.code) : null,
                 suffix: (t.email?.isNotEmpty ?? false) ? const Icon(FIcons.mail) : null,
                 onPress: (t.email?.isNotEmpty ?? false)
                     ? () => launchUrl(Uri(scheme: 'mailto', path: t.email))

--- a/lib/ui/classes/class_detail_screen.dart
+++ b/lib/ui/classes/class_detail_screen.dart
@@ -65,7 +65,7 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
       body = Center(child: Text('Not found', style: TextStyle(color: colors.mutedForeground)));
     } else {
       final students = (c.students ?? const <SchoolUserDto>[]).toList()
-        ..sort((a, b) => '${a.lastName}'.compareTo('${b.lastName}'));
+        ..sort((a, b) => a.lastName.compareTo(b.lastName));
       final exams = c.exams ?? const <ExamDto>[];
       final agenda = (c.agenda ?? const <AgendaEntryDto>[]).toList()
         ..sort((a, b) => a.date.compareTo(b.date));
@@ -89,9 +89,9 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
                   child: FTile(
                     prefix: _StudentAvatar(
                       url: OidcConfig.resolveUrl(s.profilePictureUrl),
-                      name: '${s.firstName ?? ''} ${s.lastName ?? ''}'.trim(),
+                      name: '${s.firstName} ${s.lastName}'.trim(),
                     ),
-                    title: Text('${s.firstName ?? ''} ${s.lastName ?? ''}'.trim()),
+                    title: Text('${s.firstName} ${s.lastName}'.trim()),
                   ),
                 ),
               const SizedBox(height: 12),
@@ -102,7 +102,7 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
                 Padding(
                   padding: const EdgeInsets.only(bottom: 8),
                   child: FTile(
-                    title: Text(e.name ?? 'Exam'),
+                    title: Text(e.name),
                     subtitle: Text('class ⌀ ${formatGrade(e.classAverage)}'),
                     suffix: isGraded(e.classAverage)
                         ? GradePill(e.classAverage)
@@ -118,7 +118,7 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
                   padding: const EdgeInsets.only(bottom: 8),
                   child: FTile(
                     prefix: const Icon(FIcons.calendarDays),
-                    title: Text(a.title?.isNotEmpty == true ? a.title! : 'Entry'),
+                    title: Text(a.title.isNotEmpty == true ? a.title : 'Entry'),
                     subtitle: Text('${a.date.day}.${a.date.month}.${a.date.year}'),
                   ),
                 ),

--- a/lib/ui/home/home_page.dart
+++ b/lib/ui/home/home_page.dart
@@ -60,7 +60,7 @@ class HomePage extends StatelessWidget {
             for (final l in todayEntries)
               FTile(
                 prefix: const Icon(FIcons.calendarDays),
-                title: Text(l.title?.isNotEmpty == true ? l.title! : 'Entry'),
+                title: Text(l.title.isNotEmpty == true ? l.title : 'Entry'),
                 subtitle: Text([_time(l.date), l.place].whereType<String>().where((s) => s.isNotEmpty).join(' · ')),
               ),
           ],
@@ -73,7 +73,7 @@ class HomePage extends StatelessWidget {
             for (final t in upcoming.take(5))
               FTile(
                 prefix: const Icon(FIcons.calendarDays),
-                title: Text(t.title?.isNotEmpty == true ? t.title! : 'Entry'),
+                title: Text(t.title.isNotEmpty == true ? t.title : 'Entry'),
                 subtitle: Text('${_dateLabel(t.date)} · ${_time(t.date)}'),
               ),
           ],
@@ -112,7 +112,7 @@ class HomePage extends StatelessWidget {
             for (final a in recentAbsences.take(4))
               FTile(
                 prefix: const Icon(FIcons.calendarOff),
-                title: Text(a.reason?.isNotEmpty == true ? a.reason! : 'Absence'),
+                title: Text(a.reason.isNotEmpty == true ? a.reason : 'Absence'),
                 subtitle: Text(_rangeLabel(a.from, a.until)),
               ),
           ],

--- a/lib/ui/timetable/timetable_page.dart
+++ b/lib/ui/timetable/timetable_page.dart
@@ -136,7 +136,7 @@ class _EntryTile extends StatelessWidget {
     final time = _timeRange(entry.date);
     return FTile(
       prefix: Icon(icon, color: color),
-      title: Text(entry.title?.isNotEmpty == true ? entry.title! : label),
+      title: Text(entry.title.isNotEmpty == true ? entry.title : label),
       subtitle: Text([time, entry.place].whereType<String>().where((s) => s.isNotEmpty).join(' · ')),
       suffix: _TypeBadge(label: label, color: color),
     );


### PR DESCRIPTION
## Summary

Clear ~34 `flutter analyze` warnings: remove redundant null-aware operators (`?.`), unnecessary `!` assertions, dead `?? fallback` expressions (and the dead code they created) on values the analyzer proves non-null, plus two unnecessary string interpolations. Behaviour-preserving. (Two `experimental_member_use` warnings for `toApproximateMaterialTheme` remain — inherent to that Forui API.)

Closes #311