### PR TITLE
Add AppMode service (account vs private)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
 import 'l10n/app_localizations.dart';
+import 'services/app_mode_service.dart';
 import 'services/theme_service.dart';
 import 'ui/core/ui/root_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await AppModeService.instance.load();
   await ThemeService.instance.load();
   runApp(const SchulyApp());
 }

--- a/lib/services/app_mode_service.dart
+++ b/lib/services/app_mode_service.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// How the app runs:
+/// - [account] — full mode: Pocket ID sign-in + the Schuly backend account.
+/// - [private] — no account; data is proxied statelessly and kept only on-device.
+enum AppMode { account, private }
+
+/// Holds the selected [AppMode], persisted locally. Mirrors [ThemeService]:
+/// a singleton [ChangeNotifier] loaded once at startup.
+class AppModeService extends ChangeNotifier {
+  AppModeService._();
+  static final AppModeService instance = AppModeService._();
+
+  static const _key = 'app.mode';
+
+  AppMode _mode = AppMode.account;
+  AppMode get mode => _mode;
+  bool get isPrivate => _mode == AppMode.private;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _mode = prefs.getString(_key) == AppMode.private.name
+        ? AppMode.private
+        : AppMode.account;
+    notifyListeners();
+  }
+
+  Future<void> setMode(AppMode mode) async {
+    if (_mode == mode) return;
+    _mode = mode;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, mode.name);
+  }
+}


### PR DESCRIPTION
## Summary

Add `AppModeService` — a singleton `ChangeNotifier` (mirroring `ThemeService`) holding whether the app runs in `account` or `private` mode, persisted in SharedPreferences and loaded at startup. Foundation for private mode; no behavior change yet.

Closes #313