### PR TITLE
Add SchulwareProxyClient for private mode

### DIFF
--- a/lib/domain/private_data.dart
+++ b/lib/domain/private_data.dart
@@ -1,0 +1,184 @@
+// Typed responses from the backend's stateless Schulware proxy
+// (`/api/plugins/schulware/stateless/*`), used by private mode. Field names
+// mirror the plugin's flat DTOs (camelCase JSON).
+
+class PrivateAuthorizeUrl {
+  final String? authorizationUrl;
+  final String? codeVerifier;
+  const PrivateAuthorizeUrl(this.authorizationUrl, this.codeVerifier);
+
+  factory PrivateAuthorizeUrl.fromJson(Map<String, dynamic> j) =>
+      PrivateAuthorizeUrl(j['authorizationUrl'] as String?, j['codeVerifier'] as String?);
+}
+
+class PrivateTokens {
+  final String? accessToken;
+  final String? refreshToken;
+  const PrivateTokens(this.accessToken, this.refreshToken);
+
+  factory PrivateTokens.fromJson(Map<String, dynamic> j) =>
+      PrivateTokens(j['accessToken'] as String?, j['refreshToken'] as String?);
+}
+
+class PrivateRefreshResult {
+  final bool success;
+  final String? message;
+  final String? accessToken;
+  final String? refreshToken;
+  final String? webSessionId;
+  final String? webSessionUserId;
+  final String? webSessionTransId;
+
+  /// Rotated context_state as a JSON string (re-encoded from the returned object).
+  final String? contextState;
+
+  const PrivateRefreshResult({
+    required this.success,
+    this.message,
+    this.accessToken,
+    this.refreshToken,
+    this.webSessionId,
+    this.webSessionUserId,
+    this.webSessionTransId,
+    this.contextState,
+  });
+}
+
+class PrivateGrade {
+  final String? id;
+  final String? examId;
+  final String? subject;
+  final double? score;
+  final String? date;
+  final String? comment;
+  final double? points;
+  const PrivateGrade({
+    this.id,
+    this.examId,
+    this.subject,
+    this.score,
+    this.date,
+    this.comment,
+    this.points,
+  });
+
+  factory PrivateGrade.fromJson(Map<String, dynamic> j) => PrivateGrade(
+        id: j['id'] as String?,
+        examId: j['examId'] as String?,
+        subject: j['subject'] as String?,
+        score: (j['score'] as num?)?.toDouble(),
+        date: j['date'] as String?,
+        comment: j['comment'] as String?,
+        points: (j['points'] as num?)?.toDouble(),
+      );
+}
+
+class PrivateExam {
+  final String? id;
+  final String? name;
+  final String? subject;
+  final String? startDate;
+  final String? endDate;
+  final String? room;
+  final String? comment;
+  final String? type;
+  const PrivateExam({
+    this.id,
+    this.name,
+    this.subject,
+    this.startDate,
+    this.endDate,
+    this.room,
+    this.comment,
+    this.type,
+  });
+
+  factory PrivateExam.fromJson(Map<String, dynamic> j) => PrivateExam(
+        id: j['id'] as String?,
+        name: j['name'] as String?,
+        subject: j['subject'] as String?,
+        startDate: j['startDate'] as String?,
+        endDate: j['endDate'] as String?,
+        room: j['room'] as String?,
+        comment: j['comment'] as String?,
+        type: j['type'] as String?,
+      );
+}
+
+class PrivateAbsence {
+  final String? id;
+  final String? from;
+  final String? to;
+  final String? reason;
+  final String? subject;
+  final bool? excused;
+  const PrivateAbsence({
+    this.id,
+    this.from,
+    this.to,
+    this.reason,
+    this.subject,
+    this.excused,
+  });
+
+  factory PrivateAbsence.fromJson(Map<String, dynamic> j) => PrivateAbsence(
+        id: j['id'] as String?,
+        from: j['from'] as String?,
+        to: j['to'] as String?,
+        reason: j['reason'] as String?,
+        subject: j['subject'] as String?,
+        excused: j['excused'] as bool?,
+      );
+}
+
+class PrivateAgendaEvent {
+  final String? id;
+  final String? title;
+  final String? startDate;
+  final String? endDate;
+  final String? room;
+  final String? type;
+  final String? comment;
+  const PrivateAgendaEvent({
+    this.id,
+    this.title,
+    this.startDate,
+    this.endDate,
+    this.room,
+    this.type,
+    this.comment,
+  });
+
+  factory PrivateAgendaEvent.fromJson(Map<String, dynamic> j) => PrivateAgendaEvent(
+        id: j['id'] as String?,
+        title: j['title'] as String?,
+        startDate: j['startDate'] as String?,
+        endDate: j['endDate'] as String?,
+        room: j['room'] as String?,
+        type: j['type'] as String?,
+        comment: j['comment'] as String?,
+      );
+}
+
+class PrivateUserInfo {
+  final String? firstName;
+  final String? lastName;
+  final String? email;
+  final String? birthday;
+  final String? entryDate;
+  const PrivateUserInfo({
+    this.firstName,
+    this.lastName,
+    this.email,
+    this.birthday,
+    this.entryDate,
+  });
+
+  factory PrivateUserInfo.fromJson(Map<String, dynamic> j) => PrivateUserInfo(
+        firstName: j['firstName'] as String?,
+        lastName: j['lastName'] as String?,
+        email: j['email'] as String?,
+        birthday: j['birthday'] as String?,
+        entryDate: j['entryDate'] as String?,
+      );
+}

--- a/lib/services/schulware_proxy_client.dart
+++ b/lib/services/schulware_proxy_client.dart
@@ -1,0 +1,122 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+
+import '../config/oidc_config.dart';
+import '../domain/private_data.dart';
+import 'private_account_store.dart';
+
+/// Client for the backend's stateless Schulware proxy used in private mode.
+/// All endpoints are anonymous: the caller supplies its own credentials
+/// (token + context_state) per request; nothing is stored server-side.
+class SchulwareProxyClient {
+  SchulwareProxyClient._();
+  static final SchulwareProxyClient instance = SchulwareProxyClient._();
+
+  static const _base = '/api/plugins/schulware/stateless';
+
+  final Dio _dio = Dio(BaseOptions(
+    baseUrl: OidcConfig.backendBaseUrl,
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 60),
+  ));
+
+  // --- Auth ---
+
+  /// Starts OAuth: returns the Schulnetz authorize URL + PKCE verifier.
+  Future<PrivateAuthorizeUrl> authorizeUrl(String schulnetzBaseUrl) async {
+    final res = await _dio.get<Map<String, dynamic>>(
+      '$_base/authorize-url',
+      queryParameters: {'schulnetzBaseUrl': schulnetzBaseUrl},
+    );
+    return PrivateAuthorizeUrl.fromJson(res.data ?? const {});
+  }
+
+  /// Exchanges the OAuth code for tokens.
+  Future<PrivateTokens> exchangeCode({
+    required String code,
+    required String codeVerifier,
+    String? state,
+    required String schulnetzBaseUrl,
+  }) async {
+    final res = await _dio.post<Map<String, dynamic>>(
+      '$_base/oauth/callback',
+      data: {
+        'code': code,
+        'codeVerifier': codeVerifier,
+        'state': state,
+        'schulnetzBaseUrl': schulnetzBaseUrl,
+      },
+    );
+    return PrivateTokens.fromJson(res.data ?? const {});
+  }
+
+  /// Passwordless refresh from a stored context_state (JSON string).
+  Future<PrivateRefreshResult> refresh({
+    required String schulnetzBaseUrl,
+    required String userAgent,
+    required String contextState,
+  }) async {
+    final res = await _dio.post<Map<String, dynamic>>(
+      '$_base/refresh',
+      data: {
+        'schulnetzBaseUrl': schulnetzBaseUrl,
+        'userAgent': userAgent,
+        // Send the opaque blob as a JSON object, not a string.
+        'contextState': jsonDecode(contextState),
+      },
+    );
+    final m = res.data ?? const {};
+    final rotated = m['contextState'];
+    return PrivateRefreshResult(
+      success: m['success'] as bool? ?? false,
+      message: m['message'] as String?,
+      accessToken: m['accessToken'] as String?,
+      refreshToken: m['refreshToken'] as String?,
+      webSessionId: m['webSessionId'] as String?,
+      webSessionUserId: m['webSessionUserId'] as String?,
+      webSessionTransId: m['webSessionTransId'] as String?,
+      // Re-encode the rotated context_state object back to a string for storage.
+      contextState: rotated == null ? null : jsonEncode(rotated),
+    );
+  }
+
+  // --- Data ---
+
+  Future<List<PrivateGrade>> grades(PrivateAccount a) =>
+      _list('/grades', a, PrivateGrade.fromJson);
+
+  Future<List<PrivateExam>> exams(PrivateAccount a) =>
+      _list('/exams', a, PrivateExam.fromJson);
+
+  Future<List<PrivateAbsence>> absences(PrivateAccount a) =>
+      _list('/absences', a, PrivateAbsence.fromJson);
+
+  Future<List<PrivateAgendaEvent>> agenda(PrivateAccount a) =>
+      _list('/agenda', a, PrivateAgendaEvent.fromJson);
+
+  Future<PrivateUserInfo?> userInfo(PrivateAccount a) async {
+    final res = await _dio.get<Map<String, dynamic>>(
+      '$_base/userinfo',
+      options: Options(headers: _headers(a)),
+    );
+    return res.data == null ? null : PrivateUserInfo.fromJson(res.data!);
+  }
+
+  Future<List<T>> _list<T>(
+    String path,
+    PrivateAccount a,
+    T Function(Map<String, dynamic>) fromJson,
+  ) async {
+    final res = await _dio.get<List<dynamic>>('$_base$path',
+        options: Options(headers: _headers(a)));
+    return (res.data ?? const [])
+        .map((e) => fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Map<String, String> _headers(PrivateAccount a) => {
+        'X-Schulware-Token': a.accessToken,
+        'X-Schulnetz-Base-Url': a.schulnetzBaseUrl,
+      };
+}


### PR DESCRIPTION
## Summary

Add `SchulwareProxyClient` — a Dio client for the backend's stateless Schulware proxy (`authorize-url` / `oauth/callback` / `refresh` + `grades`/`exams`/`absences`/`agenda`/`userinfo`), with typed response models in `domain/private_data.dart`. All endpoints are anonymous; credentials are passed per request via headers. Isolated; the connect flow and proxy data source build on it next.

Closes #317