### PR TITLE
Adapt proxy data into account-mode DTOs for private mode

### DIFF
--- a/lib/services/private_data_adapter.dart
+++ b/lib/services/private_data_adapter.dart
@@ -1,0 +1,76 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:schuly_api/schuly_api.dart';
+
+import '../domain/private_data.dart';
+
+/// Adapts the stateless proxy's flat private-mode DTOs into the generated
+/// `SchulyApi` DTOs the account-mode UI already renders, so private mode reuses
+/// the same screens. Date formats and a few field choices are best-guess until
+/// validated against a real account.
+class PrivateDataAdapter {
+  /// Synthetic SchoolUser id linking the private user's grades/absences.
+  static const privateSchoolUserId = 'private-self';
+
+  static DateTime? _date(String? s) =>
+      (s == null || s.isEmpty) ? null : DateTime.tryParse(s);
+
+  static DateTime _dateOr(String? s, DateTime fallback) => _date(s) ?? fallback;
+
+  static GradeDto grade(PrivateGrade g) => GradeDto((b) => b
+    ..id = g.id
+    ..score = g.score
+    ..examId = g.examId
+    ..schoolUserId = privateSchoolUserId);
+
+  static ExamDto exam(PrivateExam e) => ExamDto((b) => b
+    ..id = e.id
+    ..name = (e.name?.isNotEmpty == true ? e.name! : e.subject) ?? 'Exam'
+    ..classAverage = 0
+    ..description = e.comment);
+
+  static AbsenceDto absence(PrivateAbsence a) {
+    final from = _dateOr(a.from, DateTime.now());
+    return AbsenceDto((b) => b
+      ..id = a.id
+      ..reason = (a.reason?.isNotEmpty == true ? a.reason! : 'Absence')
+      ..type = AbsenceType.absence
+      ..from = from
+      ..until = _dateOr(a.to, from)
+      ..schoolUserId = privateSchoolUserId);
+  }
+
+  static AgendaEntryDto agendaEntry(PrivateAgendaEvent e) => AgendaEntryDto((b) => b
+    ..id = e.id
+    ..entryType = e.type?.toLowerCase() == 'holiday'
+        ? AgendaEntryType.holiday
+        : AgendaEntryType.lesson
+    ..title = (e.title?.isNotEmpty == true ? e.title! : 'Entry')
+    ..place = e.room
+    ..description = e.comment
+    ..date = _dateOr(e.startDate, DateTime.now())
+    ..endDate = _date(e.endDate)
+    ..schoolUserId = privateSchoolUserId);
+
+  static SchoolUserDto schoolUser(
+    PrivateUserInfo? info,
+    List<PrivateGrade> grades,
+    List<PrivateAbsence> absences,
+  ) =>
+      SchoolUserDto((b) => b
+        ..id = privateSchoolUserId
+        ..firstName = info?.firstName ?? ''
+        ..lastName = info?.lastName ?? ''
+        ..email = info?.email ?? ''
+        ..role = Roles.student
+        ..grades = ListBuilder<GradeDto>(grades.map(grade))
+        ..absences = ListBuilder<AbsenceDto>(absences.map(absence)));
+
+  static List<ExamDto> exams(List<PrivateExam> e) =>
+      e.map(exam).toList(growable: false);
+
+  static List<AbsenceDto> absencesList(List<PrivateAbsence> a) =>
+      a.map(absence).toList(growable: false);
+
+  static List<AgendaEntryDto> agenda(List<PrivateAgendaEvent> e) =>
+      e.map(agendaEntry).toList(growable: false);
+}

--- a/lib/services/school_data_service.dart
+++ b/lib/services/school_data_service.dart
@@ -4,6 +4,10 @@ import 'package:schuly_api/schuly_api.dart';
 
 import 'active_account_service.dart';
 import 'api_client.dart';
+import 'app_mode_service.dart';
+import 'private_account_store.dart';
+import 'private_data_adapter.dart';
+import 'schulware_proxy_client.dart';
 
 /// Loads and caches the per-school data the UI renders: the signed-in user's
 /// SchoolUser record (with nested grades/absences/classes), plus the school's
@@ -61,6 +65,11 @@ class SchoolDataService extends ChangeNotifier {
   }
 
   Future<void> refresh() async {
+    if (AppModeService.instance.isPrivate) {
+      await _refreshPrivate();
+      return;
+    }
+
     final schoolId = ActiveAccountService.instance.active?.id;
     if (schoolId == null) {
       _me = null;
@@ -134,6 +143,43 @@ class SchoolDataService extends ChangeNotifier {
       _documents = (documents.data ?? BuiltList<StudentDocumentDto>())
           .where((d) => meId == null || d.schoolUserId == meId)
           .toList(growable: false);
+    } catch (e) {
+      _error = e;
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+
+  /// Private mode: pull data from the stateless proxy with the on-device
+  /// credentials and adapt it into the same DTOs the UI renders. Nothing here
+  /// touches a Schuly account; features without a proxy source stay empty.
+  Future<void> _refreshPrivate() async {
+    final account = await PrivateAccountStore.instance.load();
+    if (account == null) {
+      clear();
+      return;
+    }
+
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      final proxy = SchulwareProxyClient.instance;
+      final info = await proxy.userInfo(account);
+      final grades = await proxy.grades(account);
+      final exams = await proxy.exams(account);
+      final absences = await proxy.absences(account);
+      final agenda = await proxy.agenda(account);
+
+      _me = PrivateDataAdapter.schoolUser(info, grades, absences);
+      _exams = PrivateDataAdapter.exams(exams);
+      _absences = PrivateDataAdapter.absencesList(absences);
+      _agenda = PrivateDataAdapter.agenda(agenda);
+      _classes = const [];
+      _reports = const [];
+      _teachers = const [];
+      _documents = const [];
     } catch (e) {
       _error = e;
     } finally {


### PR DESCRIPTION
## Summary

Add `PrivateDataAdapter` (maps the stateless proxy's flat DTOs into the generated `SchulyApi` DTOs) and branch `SchoolDataService.refresh()` on `AppMode`: in private mode it fetches via `SchulwareProxyClient` with the on-device `PrivateAccount` and adapts, so the existing account-mode screens render private-mode data unchanged. Account mode is untouched, and the private branch stays dormant until the credentials + connect flow land. Field/date mappings are best-guess pending a real-account test.

Closes #319