### PR TITLE
Wire private-mode gate + connect flow

### DIFF
--- a/lib/ui/core/ui/root_screen.dart
+++ b/lib/ui/core/ui/root_screen.dart
@@ -3,12 +3,15 @@ import 'package:forui/forui.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../services/active_account_service.dart';
+import '../../../services/app_mode_service.dart';
 import '../../../services/auth_service.dart';
+import '../../../services/private_account_store.dart';
 import '../../dashboard/dashboard_screen.dart';
+import '../../schulnetz/private_connect_screen.dart';
 
-/// Tier-1 gate: until the user has signed in with Pocket ID, nothing else is
-/// reachable. Once signed in, [DashboardScreen] owns the avatar, sidebar, and
-/// add-account flow.
+/// Tier-1 gate. In **account** mode the user signs in with Pocket ID; in
+/// **private** mode they connect a school directly (no account) and the creds
+/// live only on-device. Once past the gate, [DashboardScreen] owns the rest.
 class RootScreen extends StatefulWidget {
   const RootScreen({super.key});
 
@@ -17,31 +20,37 @@ class RootScreen extends StatefulWidget {
 }
 
 class _RootScreenState extends State<RootScreen> {
-  bool? _signedIn;
+  bool? _ready; // signed in (account) or connected (private)
   bool _busy = false;
   String? _error;
 
   @override
   void initState() {
     super.initState();
-    // React to session changes — including a failed silent refresh, which
-    // signs the user out from inside the API interceptor.
+    // React to session changes (incl. a failed silent refresh) and mode switches.
     AuthService.sessionEpoch.addListener(_refresh);
+    AppModeService.instance.addListener(_refresh);
     _refresh();
   }
 
   @override
   void dispose() {
     AuthService.sessionEpoch.removeListener(_refresh);
+    AppModeService.instance.removeListener(_refresh);
     super.dispose();
   }
 
   Future<void> _refresh() async {
+    if (AppModeService.instance.isPrivate) {
+      final account = await PrivateAccountStore.instance.load();
+      if (mounted) setState(() => _ready = account != null);
+      return;
+    }
     final token = await AuthService.getAccessToken();
     if (token == null) {
       await ActiveAccountService.instance.clear();
     }
-    if (mounted) setState(() => _signedIn = token != null);
+    if (mounted) setState(() => _ready = token != null);
   }
 
   Future<void> _signIn() async {
@@ -59,26 +68,39 @@ class _RootScreenState extends State<RootScreen> {
     }
   }
 
+  Future<void> _connectPrivate() async {
+    final ok = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(builder: (_) => const PrivateConnectScreen()),
+    );
+    if (ok == true) await _refresh();
+  }
+
   Future<void> _signOut() async {
-    await AuthService.signOut();
-    await ActiveAccountService.instance.clear();
+    if (AppModeService.instance.isPrivate) {
+      await PrivateAccountStore.instance.clear();
+      await AppModeService.instance.setMode(AppMode.account);
+    } else {
+      await AuthService.signOut();
+      await ActiveAccountService.instance.clear();
+    }
     await _refresh();
   }
 
   @override
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context)!;
-    final signedIn = _signedIn;
+    final ready = _ready;
 
-    if (signedIn == null) {
+    if (ready == null) {
       return const FScaffold(child: Center(child: FCircularProgress()));
     }
-
-    if (signedIn) {
+    if (ready) {
       return DashboardScreen(onSignOut: _signOut);
     }
 
     final colors = context.theme.colors;
+    final isPrivate = AppModeService.instance.isPrivate;
+
     return FScaffold(
       header: const FHeader(title: Text('Schuly')),
       child: Center(
@@ -86,14 +108,35 @@ class _RootScreenState extends State<RootScreen> {
           mainAxisSize: MainAxisSize.min,
           spacing: 16,
           children: [
-            const Text(
-              'Sign in to Pocket ID to use Schuly.',
-              textAlign: TextAlign.center,
-            ),
-            FButton(
-              onPress: _busy ? null : _signIn,
-              child: Text(_busy ? 'Waiting for browser…' : t.signIn),
-            ),
+            if (isPrivate) ...[
+              const Text(
+                'Private mode — no account, nothing stored on a server.',
+                textAlign: TextAlign.center,
+              ),
+              FButton(
+                onPress: _busy ? null : _connectPrivate,
+                child: const Text('Connect a school'),
+              ),
+              FButton(
+                style: FButtonStyle.outline(),
+                onPress: () => AppModeService.instance.setMode(AppMode.account),
+                child: const Text('Use an account instead'),
+              ),
+            ] else ...[
+              const Text(
+                'Sign in to Pocket ID to use Schuly.',
+                textAlign: TextAlign.center,
+              ),
+              FButton(
+                onPress: _busy ? null : _signIn,
+                child: Text(_busy ? 'Waiting for browser…' : t.signIn),
+              ),
+              FButton(
+                style: FButtonStyle.outline(),
+                onPress: () => AppModeService.instance.setMode(AppMode.private),
+                child: const Text('Use without an account'),
+              ),
+            ],
             if (_error != null)
               SelectableText(_error!,
                   style: TextStyle(color: colors.destructive)),

--- a/lib/ui/dashboard/dashboard_screen.dart
+++ b/lib/ui/dashboard/dashboard_screen.dart
@@ -3,7 +3,9 @@ import 'package:flutter/services.dart';
 import 'package:forui/forui.dart';
 
 import '../../services/active_account_service.dart';
+import '../../services/app_mode_service.dart';
 import '../../services/auth_service.dart';
+import '../../services/private_account_store.dart';
 import '../../services/school_data_service.dart';
 import '../absences/absences_page.dart';
 import '../account/account_page.dart';
@@ -27,6 +29,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
   String? _pictureUrl;
   String? _userName;
   String? _userEmail;
+  String? _privateTitle;
   int _index = 0;
 
   @override
@@ -55,6 +58,19 @@ class _DashboardScreenState extends State<DashboardScreen> {
   }
 
   Future<void> _bootstrap() async {
+    // Private mode: no Pocket ID / school switcher — just load proxied data.
+    if (AppModeService.instance.isPrivate) {
+      final account = await PrivateAccountStore.instance.load();
+      if (mounted) {
+        setState(() {
+          _userName = account?.displayName;
+          _privateTitle = account?.displayName;
+        });
+      }
+      await SchoolDataService.instance.refresh();
+      return;
+    }
+
     final claims = await AuthService.getIdTokenClaims();
     if (mounted && claims != null) {
       setState(() {
@@ -138,8 +154,11 @@ class _DashboardScreenState extends State<DashboardScreen> {
 
         return FScaffold(
           header: _TopBar(
-            title: active?.name ?? 'Schuly',
-            subtitle: active?.fullName,
+            title: AppModeService.instance.isPrivate
+                ? (_privateTitle ?? 'Schuly')
+                : (active?.name ?? 'Schuly'),
+            subtitle:
+                AppModeService.instance.isPrivate ? null : active?.fullName,
             pictureUrl: _pictureUrl,
             userName: _userName,
             onAvatar: _openSidebar,

--- a/lib/ui/schulnetz/private_connect_screen.dart
+++ b/lib/ui/schulnetz/private_connect_screen.dart
@@ -1,0 +1,137 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+
+import '../../services/private_account_store.dart';
+import '../../services/schulware_proxy_client.dart';
+import 'schulnetz_oauth_screen.dart';
+
+/// Private-mode Schulnetz connect: runs OAuth against the stateless proxy and
+/// stores the resulting credentials on-device only (no Schuly account). Pops
+/// `true` on success.
+class PrivateConnectScreen extends StatefulWidget {
+  const PrivateConnectScreen({super.key});
+
+  @override
+  State<PrivateConnectScreen> createState() => _PrivateConnectScreenState();
+}
+
+class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
+  final _urlCtrl = TextEditingController();
+  final _nameCtrl = TextEditingController(text: 'Schulnetz');
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _urlCtrl.dispose();
+    _nameCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _connect() async {
+    final url = _urlCtrl.text.trim();
+    if (url.isEmpty) {
+      setState(() => _error = 'Schulnetz URL is required');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final proxy = SchulwareProxyClient.instance;
+
+      // 1. Get the authorize URL + PKCE verifier from the stateless proxy.
+      final auth = await proxy.authorizeUrl(url);
+      if (auth.authorizationUrl == null || auth.codeVerifier == null) {
+        setState(() => _error = 'Failed to start login');
+        return;
+      }
+
+      // 2. Drive Schulnetz OAuth in the WebView, capturing code + context_state.
+      if (!mounted) return;
+      final result = await Navigator.of(context).push<SchulnetzOAuthResult>(
+        MaterialPageRoute(
+          builder: (_) => SchulnetzOAuthScreen(
+            authorizationUrl: auth.authorizationUrl!,
+            schulnetzBaseUrl: url,
+          ),
+        ),
+      );
+      if (result == null) {
+        setState(() => _error = 'Login cancelled');
+        return;
+      }
+
+      // 3. Exchange the code for tokens (stateless; nothing stored server-side).
+      final tokens = await proxy.exchangeCode(
+        code: result.code,
+        codeVerifier: auth.codeVerifier!,
+        state: result.state,
+        schulnetzBaseUrl: url,
+      );
+      if (tokens.accessToken == null) {
+        setState(() => _error = 'Token exchange failed');
+        return;
+      }
+
+      // 4. Persist everything on-device for passwordless refresh + data calls.
+      final name = _nameCtrl.text.trim();
+      await PrivateAccountStore.instance.save(PrivateAccount(
+        schulnetzBaseUrl: url,
+        displayName: name.isEmpty ? 'Schulnetz' : name,
+        accessToken: tokens.accessToken!,
+        refreshToken: tokens.refreshToken,
+        contextState: result.contextState,
+        userAgent: result.userAgent,
+      ));
+
+      if (mounted) Navigator.of(context).pop(true);
+    } on DioException catch (e) {
+      setState(() => _error =
+          'HTTP ${e.response?.statusCode ?? '?'}: ${e.response?.data}');
+    } catch (e) {
+      setState(() => _error = '$e');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    return FScaffold(
+      header: FHeader.nested(
+        title: const Text('Connect Schulnetz'),
+        prefixes: [FHeaderAction.back(onPress: () => Navigator.of(context).pop())],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        spacing: 16,
+        children: [
+          const Text(
+            'Private mode keeps everything on this device — no account, '
+            'nothing stored on a server.',
+          ),
+          FTextField(
+            control: FTextFieldControl.managed(controller: _urlCtrl),
+            label: const Text('Schulnetz URL'),
+            hint: 'https://schulnetz.example.ch',
+            keyboardType: TextInputType.url,
+          ),
+          FTextField(
+            control: FTextFieldControl.managed(controller: _nameCtrl),
+            label: const Text('Display Name'),
+          ),
+          FButton(
+            onPress: _busy ? null : _connect,
+            child: Text(_busy ? 'Working…' : 'Connect'),
+          ),
+          if (_error != null)
+            SelectableText(_error!, style: TextStyle(color: colors.destructive)),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Make private mode reachable end-to-end: a mode-aware root gate (account sign-in gains "Use without an account"; private mode shows "Connect a school" / "Use an account instead"), a `PrivateConnectScreen` that runs OAuth via the stateless proxy and stores credentials on-device, and a private-mode dashboard bootstrap that loads proxied data without an account. Account mode is fully guarded behind `AppMode`. Compile-verified; the live run needs a real Schulnetz account.

Closes #321