### PR TITLE
Add OdAOrg to private mode

### DIFF
--- a/lib/services/odaorg_proxy_client.dart
+++ b/lib/services/odaorg_proxy_client.dart
@@ -1,0 +1,61 @@
+import 'package:dio/dio.dart';
+
+import '../config/oidc_config.dart';
+import '../domain/private_data.dart';
+import 'private_account_store.dart';
+
+/// Bundle returned by the stateless OdAOrg proxy in one scrape pass.
+class OdaorgData {
+  final PrivateUserInfo? userInfo;
+  final List<PrivateGrade> grades;
+  final List<PrivateExam> exams;
+  final List<PrivateAgendaEvent> agenda;
+  const OdaorgData({
+    this.userInfo,
+    this.grades = const [],
+    this.exams = const [],
+    this.agenda = const [],
+  });
+}
+
+/// Client for the backend's stateless OdAOrg proxy used in private mode.
+/// One anonymous call scrapes with the caller's credentials and returns the
+/// data; nothing is stored server-side.
+class OdaorgProxyClient {
+  OdaorgProxyClient._();
+  static final OdaorgProxyClient instance = OdaorgProxyClient._();
+
+  static const _base = '/api/plugins/odaorg/stateless';
+
+  final Dio _dio = Dio(BaseOptions(
+    baseUrl: OidcConfig.backendBaseUrl,
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 90),
+  ));
+
+  Future<OdaorgData> data(PrivateAccount account) async {
+    final res = await _dio.post<Map<String, dynamic>>(
+      '$_base/data',
+      data: {
+        'baseUrl': account.baseUrl,
+        'username': account.username,
+        'password': account.password,
+      },
+    );
+    final m = res.data ?? const {};
+    return OdaorgData(
+      userInfo: m['userInfo'] == null
+          ? null
+          : PrivateUserInfo.fromJson(m['userInfo'] as Map<String, dynamic>),
+      grades: (m['grades'] as List<dynamic>? ?? const [])
+          .map((e) => PrivateGrade.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      exams: (m['exams'] as List<dynamic>? ?? const [])
+          .map((e) => PrivateExam.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      agenda: (m['agenda'] as List<dynamic>? ?? const [])
+          .map((e) => PrivateAgendaEvent.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}

--- a/lib/services/private_account_store.dart
+++ b/lib/services/private_account_store.dart
@@ -2,59 +2,100 @@ import 'dart:convert';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
-/// On-device credentials for a private-mode (account-free) Schulnetz connection.
-/// Held only in the device keystore — never sent to or stored on a Schuly account.
+/// On-device credentials for a private-mode (account-free) connection.
+/// Held only in the device keystore — never sent to or stored on a Schuly
+/// account. Supports both providers: Schulnetz (OAuth tokens + context_state)
+/// and OdAOrg (username/password).
 class PrivateAccount {
-  final String schulnetzBaseUrl;
+  /// `'schulnetz'` or `'odaorg'`.
+  final String provider;
+  final String baseUrl;
   final String displayName;
-  final String accessToken;
+
+  // Schulnetz (OAuth):
+  final String? accessToken;
   final String? refreshToken;
 
-  /// Opaque Playwright storage_state blob (JSON string) used for passwordless refresh.
-  final String contextState;
+  /// Opaque Playwright storage_state blob (JSON string) for passwordless refresh.
+  final String? contextState;
 
   /// Exact WebView user-agent captured at login (Microsoft pins cookies to UA).
-  final String userAgent;
+  final String? userAgent;
+
+  // OdAOrg (credentials):
+  final String? username;
+  final String? password;
 
   const PrivateAccount({
-    required this.schulnetzBaseUrl,
+    required this.provider,
+    required this.baseUrl,
     required this.displayName,
-    required this.accessToken,
-    required this.contextState,
-    required this.userAgent,
+    this.accessToken,
     this.refreshToken,
+    this.contextState,
+    this.userAgent,
+    this.username,
+    this.password,
   });
 
-  PrivateAccount copyWith({
-    String? accessToken,
+  bool get isSchulnetz => provider == 'schulnetz';
+  bool get isOdaorg => provider == 'odaorg';
+
+  factory PrivateAccount.schulnetz({
+    required String baseUrl,
+    required String displayName,
+    required String accessToken,
     String? refreshToken,
-    String? contextState,
+    required String contextState,
+    required String userAgent,
   }) =>
       PrivateAccount(
-        schulnetzBaseUrl: schulnetzBaseUrl,
+        provider: 'schulnetz',
+        baseUrl: baseUrl,
         displayName: displayName,
-        accessToken: accessToken ?? this.accessToken,
-        refreshToken: refreshToken ?? this.refreshToken,
-        contextState: contextState ?? this.contextState,
+        accessToken: accessToken,
+        refreshToken: refreshToken,
+        contextState: contextState,
         userAgent: userAgent,
       );
 
+  factory PrivateAccount.odaorg({
+    required String baseUrl,
+    required String displayName,
+    required String username,
+    required String password,
+  }) =>
+      PrivateAccount(
+        provider: 'odaorg',
+        baseUrl: baseUrl,
+        displayName: displayName,
+        username: username,
+        password: password,
+      );
+
   Map<String, dynamic> toJson() => {
-        'schulnetzBaseUrl': schulnetzBaseUrl,
+        'provider': provider,
+        'baseUrl': baseUrl,
         'displayName': displayName,
         'accessToken': accessToken,
         'refreshToken': refreshToken,
         'contextState': contextState,
         'userAgent': userAgent,
+        'username': username,
+        'password': password,
       };
 
   factory PrivateAccount.fromJson(Map<String, dynamic> json) => PrivateAccount(
-        schulnetzBaseUrl: json['schulnetzBaseUrl'] as String,
-        displayName: json['displayName'] as String? ?? 'Schulnetz',
-        accessToken: json['accessToken'] as String,
+        provider: json['provider'] as String? ?? 'schulnetz',
+        baseUrl:
+            (json['baseUrl'] ?? json['schulnetzBaseUrl']) as String? ?? '',
+        displayName: json['displayName'] as String? ?? 'School',
+        accessToken: json['accessToken'] as String?,
         refreshToken: json['refreshToken'] as String?,
-        contextState: json['contextState'] as String,
-        userAgent: json['userAgent'] as String,
+        contextState: json['contextState'] as String?,
+        userAgent: json['userAgent'] as String?,
+        username: json['username'] as String?,
+        password: json['password'] as String?,
       );
 }
 

--- a/lib/services/school_data_service.dart
+++ b/lib/services/school_data_service.dart
@@ -5,6 +5,7 @@ import 'package:schuly_api/schuly_api.dart';
 import 'active_account_service.dart';
 import 'api_client.dart';
 import 'app_mode_service.dart';
+import 'odaorg_proxy_client.dart';
 import 'private_account_store.dart';
 import 'private_data_adapter.dart';
 import 'schulware_proxy_client.dart';
@@ -165,17 +166,27 @@ class SchoolDataService extends ChangeNotifier {
     _error = null;
     notifyListeners();
     try {
-      final proxy = SchulwareProxyClient.instance;
-      final info = await proxy.userInfo(account);
-      final grades = await proxy.grades(account);
-      final exams = await proxy.exams(account);
-      final absences = await proxy.absences(account);
-      final agenda = await proxy.agenda(account);
+      if (account.isOdaorg) {
+        // OdAOrg: one scrape pass returns everything.
+        final d = await OdaorgProxyClient.instance.data(account);
+        _me = PrivateDataAdapter.schoolUser(d.userInfo, d.grades, const []);
+        _exams = PrivateDataAdapter.exams(d.exams);
+        _absences = const [];
+        _agenda = PrivateDataAdapter.agenda(d.agenda);
+      } else {
+        // Schulnetz: separate mobile endpoints.
+        final proxy = SchulwareProxyClient.instance;
+        final info = await proxy.userInfo(account);
+        final grades = await proxy.grades(account);
+        final exams = await proxy.exams(account);
+        final absences = await proxy.absences(account);
+        final agenda = await proxy.agenda(account);
 
-      _me = PrivateDataAdapter.schoolUser(info, grades, absences);
-      _exams = PrivateDataAdapter.exams(exams);
-      _absences = PrivateDataAdapter.absencesList(absences);
-      _agenda = PrivateDataAdapter.agenda(agenda);
+        _me = PrivateDataAdapter.schoolUser(info, grades, absences);
+        _exams = PrivateDataAdapter.exams(exams);
+        _absences = PrivateDataAdapter.absencesList(absences);
+        _agenda = PrivateDataAdapter.agenda(agenda);
+      }
       _classes = const [];
       _reports = const [];
       _teachers = const [];

--- a/lib/services/schulware_proxy_client.dart
+++ b/lib/services/schulware_proxy_client.dart
@@ -116,7 +116,7 @@ class SchulwareProxyClient {
   }
 
   Map<String, String> _headers(PrivateAccount a) => {
-        'X-Schulware-Token': a.accessToken,
-        'X-Schulnetz-Base-Url': a.schulnetzBaseUrl,
+        'X-Schulware-Token': a.accessToken ?? '',
+        'X-Schulnetz-Base-Url': a.baseUrl,
       };
 }

--- a/lib/ui/core/ui/root_screen.dart
+++ b/lib/ui/core/ui/root_screen.dart
@@ -7,7 +7,7 @@ import '../../../services/app_mode_service.dart';
 import '../../../services/auth_service.dart';
 import '../../../services/private_account_store.dart';
 import '../../dashboard/dashboard_screen.dart';
-import '../../schulnetz/private_connect_screen.dart';
+import '../../private/private_connect_flow.dart';
 
 /// Tier-1 gate. In **account** mode the user signs in with Pocket ID; in
 /// **private** mode they connect a school directly (no account) and the creds
@@ -69,10 +69,8 @@ class _RootScreenState extends State<RootScreen> {
   }
 
   Future<void> _connectPrivate() async {
-    final ok = await Navigator.of(context).push<bool>(
-      MaterialPageRoute(builder: (_) => const PrivateConnectScreen()),
-    );
-    if (ok == true) await _refresh();
+    final ok = await runPrivateConnectFlow(context);
+    if (ok) await _refresh();
   }
 
   Future<void> _signOut() async {

--- a/lib/ui/odaorg/private_odaorg_connect_screen.dart
+++ b/lib/ui/odaorg/private_odaorg_connect_screen.dart
@@ -1,0 +1,119 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+
+import '../../services/odaorg_proxy_client.dart';
+import '../../services/private_account_store.dart';
+
+/// Private-mode OdAOrg connect: username/password stored on-device only. The
+/// credentials are validated with one stateless scrape before saving. Pops
+/// `true` on success.
+class OdaorgPrivateConnectScreen extends StatefulWidget {
+  const OdaorgPrivateConnectScreen({super.key});
+
+  @override
+  State<OdaorgPrivateConnectScreen> createState() =>
+      _OdaorgPrivateConnectScreenState();
+}
+
+class _OdaorgPrivateConnectScreenState
+    extends State<OdaorgPrivateConnectScreen> {
+  final _urlCtrl = TextEditingController(text: 'https://odaorg.ict-bbag.ch');
+  final _userCtrl = TextEditingController();
+  final _passCtrl = TextEditingController();
+  final _nameCtrl = TextEditingController(text: 'OdAOrg');
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _urlCtrl.dispose();
+    _userCtrl.dispose();
+    _passCtrl.dispose();
+    _nameCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _connect() async {
+    final url = _urlCtrl.text.trim();
+    final user = _userCtrl.text.trim();
+    final pass = _passCtrl.text;
+    if (url.isEmpty || user.isEmpty || pass.isEmpty) {
+      setState(() => _error = 'URL, username and password are required');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final name = _nameCtrl.text.trim();
+      final account = PrivateAccount.odaorg(
+        baseUrl: url,
+        displayName: name.isEmpty ? 'OdAOrg' : name,
+        username: user,
+        password: pass,
+      );
+      // Validate the credentials with one scrape before persisting.
+      await OdaorgProxyClient.instance.data(account);
+      await PrivateAccountStore.instance.save(account);
+      if (mounted) Navigator.of(context).pop(true);
+    } on DioException catch (e) {
+      setState(() => _error =
+          'HTTP ${e.response?.statusCode ?? '?'}: ${e.response?.data}');
+    } catch (e) {
+      setState(() => _error = '$e');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    return FScaffold(
+      header: FHeader.nested(
+        title: const Text('Connect OdAOrg'),
+        prefixes: [FHeaderAction.back(onPress: () => Navigator.of(context).pop())],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        spacing: 16,
+        children: [
+          const Text(
+            'Private mode keeps everything on this device — no account, '
+            'nothing stored on a server.',
+          ),
+          FTextField(
+            control: FTextFieldControl.managed(controller: _urlCtrl),
+            label: const Text('OdAOrg URL'),
+            keyboardType: TextInputType.url,
+            autocorrect: false,
+          ),
+          FTextField(
+            control: FTextFieldControl.managed(controller: _userCtrl),
+            label: const Text('Username'),
+            hint: 'e.g. LRN26487',
+            autocorrect: false,
+          ),
+          FTextField(
+            control: FTextFieldControl.managed(controller: _passCtrl),
+            label: const Text('Password'),
+            obscureText: true,
+            autocorrect: false,
+          ),
+          FTextField(
+            control: FTextFieldControl.managed(controller: _nameCtrl),
+            label: const Text('Display Name'),
+          ),
+          FButton(
+            onPress: _busy ? null : _connect,
+            child: Text(_busy ? 'Working…' : 'Connect'),
+          ),
+          if (_error != null)
+            SelectableText(_error!, style: TextStyle(color: colors.destructive)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/private/private_connect_flow.dart
+++ b/lib/ui/private/private_connect_flow.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+import '../../services/school_systems_service.dart';
+import '../dashboard/widgets/add_school_modal.dart';
+import '../odaorg/private_odaorg_connect_screen.dart';
+import '../schulnetz/private_connect_screen.dart';
+
+/// Private-mode connect flow: show the backend's school-system picker, then run
+/// the chosen system's private connect screen. Returns true if a connection was
+/// stored on-device.
+Future<bool> runPrivateConnectFlow(BuildContext context) async {
+  final systems = await SchoolSystemsService.fetch();
+  if (!context.mounted) return false;
+
+  final key = await showAddSchoolModal(context, systems);
+  if (key == null || !context.mounted) return false;
+
+  final Widget screen = key == 'odaorg'
+      ? const OdaorgPrivateConnectScreen()
+      : const PrivateConnectScreen();
+  final ok = await Navigator.of(context)
+      .push<bool>(MaterialPageRoute(builder: (_) => screen));
+  return ok == true;
+}

--- a/lib/ui/schulnetz/private_connect_screen.dart
+++ b/lib/ui/schulnetz/private_connect_screen.dart
@@ -78,8 +78,8 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
 
       // 4. Persist everything on-device for passwordless refresh + data calls.
       final name = _nameCtrl.text.trim();
-      await PrivateAccountStore.instance.save(PrivateAccount(
-        schulnetzBaseUrl: url,
+      await PrivateAccountStore.instance.save(PrivateAccount.schulnetz(
+        baseUrl: url,
         displayName: name.isEmpty ? 'Schulnetz' : name,
         accessToken: tokens.accessToken!,
         refreshToken: tokens.refreshToken,


### PR DESCRIPTION
## Summary

Add OdAOrg to private mode. Generalizes `PrivateAccount` to both providers (`PrivateAccount.schulnetz(...)` / `.odaorg(...)`), adds `OdaorgProxyClient` (one stateless `data` call) with a provider branch in `SchoolDataService._refreshPrivate()`, an OdAOrg private connect screen (validates credentials with one fetch before saving), and a private connect flow that shows the system picker and routes to the right connect screen — used by the root gate. Compile-verified; live run needs a real account.

Closes #323