### PR TITLE
Use a clean Dio for the school-systems catalog (no OIDC in private mode)

### DIFF
--- a/lib/services/school_systems_service.dart
+++ b/lib/services/school_systems_service.dart
@@ -1,12 +1,22 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
+import '../config/oidc_config.dart';
 import '../domain/school_system.dart';
-import 'api_client.dart';
 
 /// Fetches the backend-served catalog of school systems (anonymous endpoint).
 /// The backend is the source of truth for which systems exist and how to log
 /// in; the app renders the picker from this list.
+///
+/// Uses a clean [Dio] with no OIDC interceptor: private (secure) mode relies on
+/// this catalog and must never touch the authenticated Schuly stack.
 class SchoolSystemsService {
+  static final Dio _dio = Dio(BaseOptions(
+    baseUrl: OidcConfig.backendBaseUrl,
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 15),
+  ));
+
   /// Known systems used when the catalog can't be reached (offline / backend
   /// down), so the add-school flow still works. Mirrors the backend seed.
   static const List<SchoolSystem> fallback = [
@@ -27,7 +37,7 @@ class SchoolSystemsService {
   static Future<List<SchoolSystem>> fetch() async {
     try {
       final response =
-          await ApiClient.instance.dio.get<List<dynamic>>('/api/app/school-systems');
+          await _dio.get<List<dynamic>>('/api/app/school-systems');
       final data = response.data ?? const [];
       final systems = data
           .map((e) => SchoolSystem.fromJson(e as Map<String, dynamic>))


### PR DESCRIPTION
## Summary

Secure (private) mode must never use a Schuly login / OIDC. `SchoolSystemsService` (the catalog picker, used by private mode) went through `ApiClient.instance.dio` — the OIDC-aware client that attaches the Pocket ID bearer and signs the user out on a 401. It now uses its own clean `Dio` (no auth interceptor) against the anonymous `/api/app/school-systems` endpoint. Combined with `root_screen._refresh()` already returning early in private mode, private mode now touches zero OIDC.

Closes #329