### PR TITLE
Route private-mode endpoints via the catalog's statelessBasePath

### DIFF
--- a/lib/domain/school_system.dart
+++ b/lib/domain/school_system.dart
@@ -7,6 +7,10 @@ class SchoolSystem {
   final String? logoUrl;
   final String? schulwareApiBaseUrl;
 
+  /// Base path of this system's stateless plugin endpoints (private mode),
+  /// e.g. `/api/plugins/schulware/stateless`. Served by the catalog.
+  final String? statelessBasePath;
+
   /// How the app drives the login: `oauth-webview` or `credentials`.
   final String loginMethod;
   final bool enabled;
@@ -19,10 +23,19 @@ class SchoolSystem {
     required this.loginMethod,
     this.logoUrl,
     this.schulwareApiBaseUrl,
+    this.statelessBasePath,
     this.enabled = true,
     this.sortOrder = 0,
     this.loginFields = const [],
   });
+
+  /// The stateless base path, falling back to the conventional plugin route by
+  /// login method for catalogs that predate the `statelessBasePath` field.
+  String get resolvedStatelessBasePath =>
+      statelessBasePath ??
+      (loginMethod == 'credentials'
+          ? '/api/plugins/odaorg/stateless'
+          : '/api/plugins/schulware/stateless');
 
   factory SchoolSystem.fromJson(Map<String, dynamic> json) {
     final fields = (json['loginFields'] as List<dynamic>? ?? [])
@@ -33,6 +46,7 @@ class SchoolSystem {
       displayName: json['displayName'] as String,
       logoUrl: json['logoUrl'] as String?,
       schulwareApiBaseUrl: json['schulwareApiBaseUrl'] as String?,
+      statelessBasePath: json['statelessBasePath'] as String?,
       loginMethod: json['loginMethod'] as String? ?? 'oauth-webview',
       enabled: json['enabled'] as bool? ?? true,
       sortOrder: json['sortOrder'] as int? ?? 0,

--- a/lib/services/odaorg_proxy_client.dart
+++ b/lib/services/odaorg_proxy_client.dart
@@ -25,8 +25,6 @@ class OdaorgProxyClient {
   OdaorgProxyClient._();
   static final OdaorgProxyClient instance = OdaorgProxyClient._();
 
-  static const _base = '/api/plugins/odaorg/stateless';
-
   final Dio _dio = Dio(BaseOptions(
     baseUrl: OidcConfig.backendBaseUrl,
     connectTimeout: const Duration(seconds: 10),
@@ -35,7 +33,7 @@ class OdaorgProxyClient {
 
   Future<OdaorgData> data(PrivateAccount account) async {
     final res = await _dio.post<Map<String, dynamic>>(
-      '$_base/data',
+      '${account.statelessBasePath}/data',
       data: {
         'baseUrl': account.baseUrl,
         'username': account.username,

--- a/lib/services/private_account_store.dart
+++ b/lib/services/private_account_store.dart
@@ -15,6 +15,9 @@ class PrivateAccount {
   final String baseUrl;
   final String displayName;
 
+  /// Base path of the system's stateless plugin endpoints (from the catalog).
+  final String statelessBasePath;
+
   // oauth-webview:
   final String? accessToken;
   final String? refreshToken;
@@ -34,6 +37,7 @@ class PrivateAccount {
     required this.loginMethod,
     required this.baseUrl,
     required this.displayName,
+    required this.statelessBasePath,
     this.accessToken,
     this.refreshToken,
     this.contextState,
@@ -49,6 +53,7 @@ class PrivateAccount {
         'loginMethod': loginMethod,
         'baseUrl': baseUrl,
         'displayName': displayName,
+        'statelessBasePath': statelessBasePath,
         'accessToken': accessToken,
         'refreshToken': refreshToken,
         'contextState': contextState,
@@ -62,6 +67,10 @@ class PrivateAccount {
         loginMethod: json['loginMethod'] as String? ?? 'oauth-webview',
         baseUrl: json['baseUrl'] as String? ?? '',
         displayName: json['displayName'] as String? ?? 'School',
+        statelessBasePath: json['statelessBasePath'] as String? ??
+            ((json['loginMethod'] as String? ?? 'oauth-webview') == 'credentials'
+                ? '/api/plugins/odaorg/stateless'
+                : '/api/plugins/schulware/stateless'),
         accessToken: json['accessToken'] as String?,
         refreshToken: json['refreshToken'] as String?,
         contextState: json['contextState'] as String?,

--- a/lib/services/school_systems_service.dart
+++ b/lib/services/school_systems_service.dart
@@ -24,12 +24,14 @@ class SchoolSystemsService {
       key: 'schulnetz',
       displayName: 'Schulnetz',
       loginMethod: 'oauth-webview',
+      statelessBasePath: '/api/plugins/schulware/stateless',
       sortOrder: 0,
     ),
     SchoolSystem(
       key: 'odaorg',
       displayName: 'OdAOrg',
       loginMethod: 'credentials',
+      statelessBasePath: '/api/plugins/odaorg/stateless',
       sortOrder: 1,
     ),
   ];

--- a/lib/services/schulware_proxy_client.dart
+++ b/lib/services/schulware_proxy_client.dart
@@ -13,8 +13,6 @@ class SchulwareProxyClient {
   SchulwareProxyClient._();
   static final SchulwareProxyClient instance = SchulwareProxyClient._();
 
-  static const _base = '/api/plugins/schulware/stateless';
-
   final Dio _dio = Dio(BaseOptions(
     baseUrl: OidcConfig.backendBaseUrl,
     connectTimeout: const Duration(seconds: 10),
@@ -24,9 +22,10 @@ class SchulwareProxyClient {
   // --- Auth ---
 
   /// Starts OAuth: returns the Schulnetz authorize URL + PKCE verifier.
-  Future<PrivateAuthorizeUrl> authorizeUrl(String schulnetzBaseUrl) async {
+  Future<PrivateAuthorizeUrl> authorizeUrl(
+      String basePath, String schulnetzBaseUrl) async {
     final res = await _dio.get<Map<String, dynamic>>(
-      '$_base/authorize-url',
+      '$basePath/authorize-url',
       queryParameters: {'schulnetzBaseUrl': schulnetzBaseUrl},
     );
     return PrivateAuthorizeUrl.fromJson(res.data ?? const {});
@@ -34,13 +33,14 @@ class SchulwareProxyClient {
 
   /// Exchanges the OAuth code for tokens.
   Future<PrivateTokens> exchangeCode({
+    required String basePath,
     required String code,
     required String codeVerifier,
     String? state,
     required String schulnetzBaseUrl,
   }) async {
     final res = await _dio.post<Map<String, dynamic>>(
-      '$_base/oauth/callback',
+      '$basePath/oauth/callback',
       data: {
         'code': code,
         'codeVerifier': codeVerifier,
@@ -53,12 +53,13 @@ class SchulwareProxyClient {
 
   /// Passwordless refresh from a stored context_state (JSON string).
   Future<PrivateRefreshResult> refresh({
+    required String basePath,
     required String schulnetzBaseUrl,
     required String userAgent,
     required String contextState,
   }) async {
     final res = await _dio.post<Map<String, dynamic>>(
-      '$_base/refresh',
+      '$basePath/refresh',
       data: {
         'schulnetzBaseUrl': schulnetzBaseUrl,
         'userAgent': userAgent,
@@ -97,7 +98,7 @@ class SchulwareProxyClient {
 
   Future<PrivateUserInfo?> userInfo(PrivateAccount a) async {
     final res = await _dio.get<Map<String, dynamic>>(
-      '$_base/userinfo',
+      '${a.statelessBasePath}/userinfo',
       options: Options(headers: _headers(a)),
     );
     return res.data == null ? null : PrivateUserInfo.fromJson(res.data!);
@@ -140,6 +141,7 @@ class SchulwareProxyClient {
   Future<PrivateAccount?> _refreshAccount(PrivateAccount a) async {
     if (a.contextState == null || a.userAgent == null) return null;
     final r = await refresh(
+      basePath: a.statelessBasePath,
       schulnetzBaseUrl: a.baseUrl,
       userAgent: a.userAgent!,
       contextState: a.contextState!,
@@ -150,6 +152,7 @@ class SchulwareProxyClient {
       loginMethod: a.loginMethod,
       baseUrl: a.baseUrl,
       displayName: a.displayName,
+      statelessBasePath: a.statelessBasePath,
       accessToken: r.accessToken,
       refreshToken: r.refreshToken ?? a.refreshToken,
       contextState: r.contextState ?? a.contextState,
@@ -162,7 +165,7 @@ class SchulwareProxyClient {
     PrivateAccount a,
     T Function(Map<String, dynamic>) fromJson,
   ) async {
-    final res = await _dio.get<List<dynamic>>('$_base$path',
+    final res = await _dio.get<List<dynamic>>('${a.statelessBasePath}$path',
         options: Options(headers: _headers(a)));
     return (res.data ?? const [])
         .map((e) => fromJson(e as Map<String, dynamic>))

--- a/lib/ui/private/private_connect_screen.dart
+++ b/lib/ui/private/private_connect_screen.dart
@@ -75,8 +75,9 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
   }
 
   Future<void> _connectOauth(String baseUrl, String name) async {
+    final basePath = _system.resolvedStatelessBasePath;
     final proxy = SchulwareProxyClient.instance;
-    final auth = await proxy.authorizeUrl(baseUrl);
+    final auth = await proxy.authorizeUrl(basePath, baseUrl);
     if (auth.authorizationUrl == null || auth.codeVerifier == null) {
       setState(() => _error = 'Failed to start login');
       return;
@@ -95,6 +96,7 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
       return;
     }
     final tokens = await proxy.exchangeCode(
+      basePath: basePath,
       code: result.code,
       codeVerifier: auth.codeVerifier!,
       state: result.state,
@@ -109,6 +111,7 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
       loginMethod: _system.loginMethod,
       baseUrl: baseUrl,
       displayName: name,
+      statelessBasePath: basePath,
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
       contextState: result.contextState,
@@ -123,6 +126,7 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
       loginMethod: _system.loginMethod,
       baseUrl: baseUrl,
       displayName: name,
+      statelessBasePath: _system.resolvedStatelessBasePath,
       username: _form.value('username'),
       password: _form.value('password'),
     );


### PR DESCRIPTION
## Summary

Consume the catalog's `statelessBasePath` (SchulyBackend #137) so the private-mode proxy clients no longer hardcode `/api/plugins/.../stateless` routes. `SchoolSystem.statelessBasePath` (with a `resolvedStatelessBasePath` fallback for older catalogs) flows into `PrivateAccount` at connect time, and `SchulwareProxyClient`/`OdaorgProxyClient` take the path from the account (auth calls take a `basePath` arg). Offline fallback systems mirror the seed paths, so the proxy clients contain zero hardcoded plugin routes.

Closes #335