### PR TITLE
Derive classes in private mode

### DIFF
--- a/lib/services/private_data_adapter.dart
+++ b/lib/services/private_data_adapter.dart
@@ -73,4 +73,29 @@ class PrivateDataAdapter {
 
   static List<AgendaEntryDto> agenda(List<PrivateAgendaEvent> e) =>
       e.map(agendaEntry).toList(growable: false);
+
+  /// Derives the student's classes from the distinct subjects across their
+  /// grades and exams, attaching each subject's exams — mirroring how the
+  /// account-mode backend sync creates a Class per course. (SchulwareAPI mobile
+  /// has no standalone classes endpoint, so this is the private-mode analogue.)
+  static List<ClassDto> classes(
+    List<PrivateGrade> grades,
+    List<PrivateExam> exams,
+  ) {
+    final subjects = <String>{};
+    for (final g in grades) {
+      if (g.subject != null && g.subject!.isNotEmpty) subjects.add(g.subject!);
+    }
+    for (final e in exams) {
+      if (e.subject != null && e.subject!.isNotEmpty) subjects.add(e.subject!);
+    }
+    final sorted = subjects.toList()..sort();
+    return sorted
+        .map((subject) => ClassDto((b) => b
+          ..id = 'private-class-$subject'
+          ..name = subject
+          ..exams = ListBuilder<ExamDto>(
+              exams.where((e) => e.subject == subject).map(exam))))
+        .toList(growable: false);
+  }
 }

--- a/lib/services/school_data_service.dart
+++ b/lib/services/school_data_service.dart
@@ -177,6 +177,7 @@ class SchoolDataService extends ChangeNotifier {
         _exams = PrivateDataAdapter.exams(d.exams);
         _absences = PrivateDataAdapter.absencesList(d.absences);
         _agenda = PrivateDataAdapter.agenda(d.agenda);
+        _classes = PrivateDataAdapter.classes(d.grades, d.exams);
       } else {
         // Credentials systems (OdAOrg): one scrape pass returns everything.
         final d = await OdaorgProxyClient.instance.data(account);
@@ -184,8 +185,10 @@ class SchoolDataService extends ChangeNotifier {
         _exams = PrivateDataAdapter.exams(d.exams);
         _absences = const [];
         _agenda = PrivateDataAdapter.agenda(d.agenda);
+        _classes = PrivateDataAdapter.classes(d.grades, d.exams);
       }
-      _classes = const [];
+      // Reports, teachers and documents are scraper-only / not exposed by
+      // SchulwareAPI mobile, so they have no stateless source in private mode.
       _reports = const [];
       _teachers = const [];
       _documents = const [];


### PR DESCRIPTION
## Summary

Close the achievable part of private-mode feature parity. SchulwareAPI mobile has no standalone classes endpoint (the account-mode sync *derives* a Class per course from grades), and reports/teachers/documents are scraper-only — so:

- Add `PrivateDataAdapter.classes(grades, exams)` building one class per distinct subject (with that subject's exams), and populate `_classes` in both private branches (Schulnetz + OdAOrg). Purely app-side.
- Reports/teachers/documents have no stateless source; they stay empty, now documented in-code.

Closes #339