### PR TITLE
Remove hardcoded system fallback — backend is sole source of truth

### DIFF
--- a/lib/domain/school_system.dart
+++ b/lib/domain/school_system.dart
@@ -29,14 +29,6 @@ class SchoolSystem {
     this.loginFields = const [],
   });
 
-  /// The stateless base path, falling back to the conventional plugin route by
-  /// login method for catalogs that predate the `statelessBasePath` field.
-  String get resolvedStatelessBasePath =>
-      statelessBasePath ??
-      (loginMethod == 'credentials'
-          ? '/api/plugins/odaorg/stateless'
-          : '/api/plugins/schulware/stateless');
-
   factory SchoolSystem.fromJson(Map<String, dynamic> json) {
     final fields = (json['loginFields'] as List<dynamic>? ?? [])
         .map((e) => SchoolSystemLoginField.fromJson(e as Map<String, dynamic>))

--- a/lib/services/private_account_store.dart
+++ b/lib/services/private_account_store.dart
@@ -67,10 +67,7 @@ class PrivateAccount {
         loginMethod: json['loginMethod'] as String? ?? 'oauth-webview',
         baseUrl: json['baseUrl'] as String? ?? '',
         displayName: json['displayName'] as String? ?? 'School',
-        statelessBasePath: json['statelessBasePath'] as String? ??
-            ((json['loginMethod'] as String? ?? 'oauth-webview') == 'credentials'
-                ? '/api/plugins/odaorg/stateless'
-                : '/api/plugins/schulware/stateless'),
+        statelessBasePath: json['statelessBasePath'] as String? ?? '',
         accessToken: json['accessToken'] as String?,
         refreshToken: json['refreshToken'] as String?,
         contextState: json['contextState'] as String?,

--- a/lib/services/school_systems_service.dart
+++ b/lib/services/school_systems_service.dart
@@ -1,15 +1,16 @@
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
 
 import '../config/oidc_config.dart';
 import '../domain/school_system.dart';
 
 /// Fetches the backend-served catalog of school systems (anonymous endpoint).
-/// The backend is the source of truth for which systems exist and how to log
-/// in; the app renders the picker from this list.
+/// The backend is the **sole** source of truth for which systems exist and how
+/// to log in — the app hardcodes nothing and renders the picker + login forms
+/// entirely from this list.
 ///
 /// Uses a clean [Dio] with no OIDC interceptor: private (secure) mode relies on
-/// this catalog and must never touch the authenticated Schuly stack.
+/// this catalog and must never touch the authenticated Schuly stack. Throws if
+/// the catalog can't be reached; callers surface that to the user.
 class SchoolSystemsService {
   static final Dio _dio = Dio(BaseOptions(
     baseUrl: OidcConfig.backendBaseUrl,
@@ -17,39 +18,13 @@ class SchoolSystemsService {
     receiveTimeout: const Duration(seconds: 15),
   ));
 
-  /// Known systems used when the catalog can't be reached (offline / backend
-  /// down), so the add-school flow still works. Mirrors the backend seed.
-  static const List<SchoolSystem> fallback = [
-    SchoolSystem(
-      key: 'schulnetz',
-      displayName: 'Schulnetz',
-      loginMethod: 'oauth-webview',
-      statelessBasePath: '/api/plugins/schulware/stateless',
-      sortOrder: 0,
-    ),
-    SchoolSystem(
-      key: 'odaorg',
-      displayName: 'OdAOrg',
-      loginMethod: 'credentials',
-      statelessBasePath: '/api/plugins/odaorg/stateless',
-      sortOrder: 1,
-    ),
-  ];
-
   static Future<List<SchoolSystem>> fetch() async {
-    try {
-      final response =
-          await _dio.get<List<dynamic>>('/api/app/school-systems');
-      final data = response.data ?? const [];
-      final systems = data
-          .map((e) => SchoolSystem.fromJson(e as Map<String, dynamic>))
-          .where((s) => s.enabled)
-          .toList()
-        ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
-      return systems.isEmpty ? fallback : systems;
-    } catch (e) {
-      debugPrint('SchoolSystemsService: falling back to bundled systems: $e');
-      return fallback;
-    }
+    final response = await _dio.get<List<dynamic>>('/api/app/school-systems');
+    final data = response.data ?? const [];
+    return data
+        .map((e) => SchoolSystem.fromJson(e as Map<String, dynamic>))
+        .where((s) => s.enabled)
+        .toList()
+      ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
   }
 }

--- a/lib/ui/dashboard/widgets/add_school_modal.dart
+++ b/lib/ui/dashboard/widgets/add_school_modal.dart
@@ -22,8 +22,8 @@ Future<String?> runAddSchoolFlow(
   BuildContext context,
   NavigatorState navigator,
 ) async {
-  final systems = await SchoolSystemsService.fetch();
-  if (!context.mounted) return null;
+  final systems = await fetchSystemsOrShowError(context);
+  if (systems == null || !context.mounted) return null;
 
   final systemKey = await showAddSchoolModal(context, systems);
   if (systemKey == null) return null;
@@ -37,6 +37,45 @@ Future<String?> runAddSchoolFlow(
   };
   return navigator.push<String>(MaterialPageRoute(builder: (_) => screen));
 }
+
+/// Fetches the catalog, showing an error dialog and returning null on failure
+/// (or when the backend advertises no systems). The app keeps no offline
+/// fallback — the backend is the sole source of truth.
+Future<List<SchoolSystem>?> fetchSystemsOrShowError(BuildContext context) async {
+  List<SchoolSystem> systems;
+  try {
+    systems = await SchoolSystemsService.fetch();
+  } catch (_) {
+    if (context.mounted) {
+      await _showCatalogError(
+          context, "Couldn't reach the server. Check your connection and try again.");
+    }
+    return null;
+  }
+  if (systems.isEmpty) {
+    if (context.mounted) {
+      await _showCatalogError(context, 'No school systems are available yet.');
+    }
+    return null;
+  }
+  return systems;
+}
+
+Future<void> _showCatalogError(BuildContext context, String message) =>
+    showFDialog<void>(
+      context: context,
+      builder: (ctx, style, animation) => FDialog(
+        animation: animation,
+        title: const Text('School systems unavailable'),
+        body: Text(message),
+        actions: [
+          FButton(
+            onPress: () => Navigator.of(ctx).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
 
 /// Shows the school-system picker for [systems]. Resolves to the chosen
 /// [SchoolSystem.key] or `null` if the user dismissed.

--- a/lib/ui/private/private_connect_flow.dart
+++ b/lib/ui/private/private_connect_flow.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../../services/school_systems_service.dart';
 import '../dashboard/widgets/add_school_modal.dart';
 import 'private_connect_screen.dart';
 
@@ -8,8 +7,8 @@ import 'private_connect_screen.dart';
 /// the generic connect screen for the chosen system (driven entirely by the
 /// catalog descriptor). Returns true if a connection was stored on-device.
 Future<bool> runPrivateConnectFlow(BuildContext context) async {
-  final systems = await SchoolSystemsService.fetch();
-  if (!context.mounted) return false;
+  final systems = await fetchSystemsOrShowError(context);
+  if (systems == null || !context.mounted) return false;
 
   final key = await showAddSchoolModal(context, systems);
   if (key == null || !context.mounted) return false;

--- a/lib/ui/private/private_connect_screen.dart
+++ b/lib/ui/private/private_connect_screen.dart
@@ -59,10 +59,16 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
           : _nameCtrl.text.trim();
       final baseUrl = _form.value('baseUrl');
 
+      final basePath = _system.statelessBasePath;
+      if (basePath == null || basePath.isEmpty) {
+        setState(() => _error = 'This system is not configured for private mode');
+        return;
+      }
+
       if (_system.loginMethod == 'oauth-webview') {
-        await _connectOauth(baseUrl, name);
+        await _connectOauth(baseUrl, name, basePath);
       } else {
-        await _connectCredentials(baseUrl, name);
+        await _connectCredentials(baseUrl, name, basePath);
       }
     } on DioException catch (e) {
       setState(() => _error =
@@ -74,8 +80,7 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
     }
   }
 
-  Future<void> _connectOauth(String baseUrl, String name) async {
-    final basePath = _system.resolvedStatelessBasePath;
+  Future<void> _connectOauth(String baseUrl, String name, String basePath) async {
     final proxy = SchulwareProxyClient.instance;
     final auth = await proxy.authorizeUrl(basePath, baseUrl);
     if (auth.authorizationUrl == null || auth.codeVerifier == null) {
@@ -120,13 +125,14 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
     if (mounted) Navigator.of(context).pop(true);
   }
 
-  Future<void> _connectCredentials(String baseUrl, String name) async {
+  Future<void> _connectCredentials(
+      String baseUrl, String name, String basePath) async {
     final account = PrivateAccount(
       systemKey: _system.key,
       loginMethod: _system.loginMethod,
       baseUrl: baseUrl,
       displayName: name,
-      statelessBasePath: _system.resolvedStatelessBasePath,
+      statelessBasePath: basePath,
       username: _form.value('username'),
       password: _form.value('password'),
     );


### PR DESCRIPTION
## Summary

Remove the last place the frontend decides what you can authenticate with. The backend catalog is now the sole source of truth: drop `SchoolSystemsService.fallback` (`fetch()` throws on failure), `SchoolSystem.resolvedStatelessBasePath`, and the `PrivateAccount.fromJson` path default. The connect screen validates `statelessBasePath` from the catalog, and the add-school / private-connect flows show an error dialog when the catalog can't be reached or is empty.

Closes #341