### PR TITLE
Remove all provider knowledge from the frontend (catalog-driven plugin routes + logos)

### DIFF
--- a/lib/domain/school_system.dart
+++ b/lib/domain/school_system.dart
@@ -11,6 +11,11 @@ class SchoolSystem {
   /// e.g. `/api/plugins/schulware/stateless`. Served by the catalog.
   final String? statelessBasePath;
 
+  /// Base path of this system's plugin endpoints (account mode:
+  /// accounts/sync/status), e.g. `/api/plugins/schulware`. Served by the
+  /// catalog because the system key differs from the plugin name.
+  final String? pluginBasePath;
+
   /// How the app drives the login: `oauth-webview` or `credentials`.
   final String loginMethod;
   final bool enabled;
@@ -24,6 +29,7 @@ class SchoolSystem {
     this.logoUrl,
     this.schulwareApiBaseUrl,
     this.statelessBasePath,
+    this.pluginBasePath,
     this.enabled = true,
     this.sortOrder = 0,
     this.loginFields = const [],
@@ -39,6 +45,7 @@ class SchoolSystem {
       logoUrl: json['logoUrl'] as String?,
       schulwareApiBaseUrl: json['schulwareApiBaseUrl'] as String?,
       statelessBasePath: json['statelessBasePath'] as String?,
+      pluginBasePath: json['pluginBasePath'] as String?,
       loginMethod: json['loginMethod'] as String? ?? 'oauth-webview',
       enabled: json['enabled'] as bool? ?? true,
       sortOrder: json['sortOrder'] as int? ?? 0,

--- a/lib/domain/schulware_account.dart
+++ b/lib/domain/schulware_account.dart
@@ -4,14 +4,17 @@ import '../config/oidc_config.dart';
 
 /// A school the signed-in user belongs to, from `GET /api/schools/my-schools`.
 /// Carries the school name plus the user's identity (full name + email) at
-/// that school — what the account switcher displays. [provider] is inferred
-/// from which plugin owns the school's SchoolUser (the API doesn't expose it).
+/// that school — what the account switcher displays. [provider] is the catalog
+/// system key, and [pluginBasePath] its plugin route — both discovered from the
+/// backend catalog, never hardcoded.
 class MySchool {
   final String id;
   final String name;
   final String? email;
   final String? fullName;
-  final String provider; // 'schulnetz' | 'odaorg'
+  final String provider;
+  /// Catalog plugin base path backing this school (accounts/sync/status).
+  final String? pluginBasePath;
   /// The plugin account id backing this school (for triggering a sync).
   final String? pluginAccountId;
   /// Backend-supplied, fully-resolved URLs (null if not provided).
@@ -23,7 +26,8 @@ class MySchool {
     required this.name,
     this.email,
     this.fullName,
-    this.provider = 'schulnetz',
+    this.provider = '',
+    this.pluginBasePath,
     this.pluginAccountId,
     this.logoUrl,
     this.profilePictureUrl,
@@ -31,7 +35,8 @@ class MySchool {
 
   factory MySchool.fromDto(
     MySchoolDto dto, {
-    String provider = 'schulnetz',
+    String provider = '',
+    String? pluginBasePath,
     String? pluginAccountId,
   }) =>
       MySchool(
@@ -40,14 +45,9 @@ class MySchool {
         email: dto.email,
         fullName: dto.fullName,
         provider: provider,
+        pluginBasePath: pluginBasePath,
         pluginAccountId: pluginAccountId,
         logoUrl: OidcConfig.resolveUrl(dto.logoUrl),
         profilePictureUrl: OidcConfig.resolveUrl(dto.profilePictureUrl),
       );
-
-  /// Fallback asset for this provider's logo when [logoUrl] is null.
-  String get logoAsset => switch (provider) {
-        'odaorg' => 'assets/schoolsystems/odaorg.webp',
-        _ => 'assets/schoolsystems/schulnetz.webp',
-      };
 }

--- a/lib/services/active_account_service.dart
+++ b/lib/services/active_account_service.dart
@@ -2,8 +2,10 @@ import 'package:flutter/foundation.dart';
 import 'package:schuly_api/schuly_api.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../domain/school_system.dart';
 import '../domain/schulware_account.dart';
 import 'api_client.dart';
+import 'school_systems_service.dart';
 
 /// App-wide source of truth for "which connected school is the user currently
 /// looking at". Backed by `GET /api/schools/my-schools`. Listens-friendly via
@@ -49,7 +51,8 @@ class ActiveAccountService extends ChangeNotifier {
           : data.map((dto) {
               final info = pluginBySchoolId[dto.id];
               return MySchool.fromDto(dto,
-                  provider: info?.provider ?? 'schulnetz',
+                  provider: info?.provider ?? '',
+                  pluginBasePath: info?.pluginBasePath,
                   pluginAccountId: info?.accountId);
             }).toList(growable: false);
 
@@ -74,13 +77,16 @@ class ActiveAccountService extends ChangeNotifier {
     }
   }
 
-  /// Maps schoolId → (provider, plugin account id) by cross-referencing each
-  /// plugin's accounts (which expose `schoolUserId` + `id`) against the user's
-  /// SchoolUsers. Best-effort: returns an empty map on any failure so the
-  /// account list still loads.
-  Future<Map<String, ({String provider, String accountId})>> _detectPluginAccounts() async {
+  /// Maps schoolId → (provider, plugin account id, plugin base path) by
+  /// cross-referencing each catalog system's plugin accounts (which expose
+  /// `schoolUserId` + `id`) against the user's SchoolUsers. The set of plugins
+  /// and their routes comes entirely from the backend catalog — no provider is
+  /// hardcoded. Best-effort: returns an empty map on any failure.
+  Future<Map<String, ({String provider, String accountId, String? pluginBasePath})>>
+      _detectPluginAccounts() async {
     try {
       final api = ApiClient.instance.api;
+      final dio = ApiClient.instance.dio;
       final me = await api.getAuthApi().apiAuthMeGet();
       final appUserId = me.data?.id;
       if (appUserId == null) return const {};
@@ -92,22 +98,31 @@ class ActiveAccountService extends ChangeNotifier {
           if (u.id != null && u.schoolId != null) u.id!: u.schoolId!,
       };
 
-      final out = <String, ({String provider, String accountId})>{};
-      void mapAccounts(List<dynamic> accounts, String provider) {
-        for (final a in accounts.cast<Map<String, dynamic>>()) {
-          final suId = a['schoolUserId'] as String?;
-          final accId = a['id'] as String?;
-          final schoolId = suId == null ? null : schoolIdByUser[suId];
-          if (schoolId != null && accId != null) {
-            out[schoolId] = (provider: provider, accountId: accId);
-          }
-        }
+      List<SchoolSystem> systems;
+      try {
+        systems = await SchoolSystemsService.fetch();
+      } catch (_) {
+        systems = const [];
       }
 
-      final oda = await api.getAccountsApi().apiPluginsOdaorgAccountsGet();
-      mapAccounts((oda.data as List<dynamic>?) ?? const [], 'odaorg');
-      final schul = await api.getAccountsApi().apiPluginsSchulwareAccountsGet();
-      mapAccounts((schul.data as List<dynamic>?) ?? const [], 'schulnetz');
+      final out =
+          <String, ({String provider, String accountId, String? pluginBasePath})>{};
+      for (final sys in systems) {
+        final base = sys.pluginBasePath;
+        if (base == null || base.isEmpty) continue;
+        try {
+          final res = await dio.get<List<dynamic>>('$base/accounts');
+          for (final a in (res.data ?? const []).cast<Map<String, dynamic>>()) {
+            final suId = a['schoolUserId'] as String?;
+            final accId = a['id'] as String?;
+            final schoolId = suId == null ? null : schoolIdByUser[suId];
+            if (schoolId != null && accId != null) {
+              out[schoolId] =
+                  (provider: sys.key, accountId: accId, pluginBasePath: base);
+            }
+          }
+        } catch (_) {/* skip this plugin */}
+      }
       return out;
     } catch (_) {
       return const {};
@@ -122,17 +137,13 @@ class ActiveAccountService extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Disconnects a connected school via its plugin's DELETE endpoint, then
-  /// reloads the account list (which reselects an active school).
+  /// Disconnects a connected school via its plugin's DELETE endpoint (built from
+  /// the catalog's plugin base path), then reloads the account list.
   Future<void> removeSchool(MySchool school) async {
     final accountId = school.pluginAccountId;
-    if (accountId == null) return;
-    final accounts = ApiClient.instance.api.getAccountsApi();
-    if (school.provider == 'odaorg') {
-      await accounts.apiPluginsOdaorgAccountsAccountIdDelete(accountId: accountId);
-    } else {
-      await accounts.apiPluginsSchulwareAccountsAccountIdDelete(accountId: accountId);
-    }
+    final base = school.pluginBasePath;
+    if (accountId == null || base == null || base.isEmpty) return;
+    await ApiClient.instance.dio.delete<dynamic>('$base/accounts/$accountId');
     // If we removed the active school, drop the selection so refresh picks a new one.
     if (_activeId == school.id) {
       _activeId = null;

--- a/lib/services/private_account_store.dart
+++ b/lib/services/private_account_store.dart
@@ -63,7 +63,7 @@ class PrivateAccount {
       };
 
   factory PrivateAccount.fromJson(Map<String, dynamic> json) => PrivateAccount(
-        systemKey: json['systemKey'] as String? ?? 'schulnetz',
+        systemKey: json['systemKey'] as String? ?? '',
         loginMethod: json['loginMethod'] as String? ?? 'oauth-webview',
         baseUrl: json['baseUrl'] as String? ?? '',
         displayName: json['displayName'] as String? ?? 'School',

--- a/lib/ui/account/account_page.dart
+++ b/lib/ui/account/account_page.dart
@@ -50,12 +50,11 @@ class _AccountPageState extends State<AccountPage> {
     try {
       final active = ActiveAccountService.instance.active;
       final accountId = active?.pluginAccountId;
-      if (accountId == null) return;
-      final sync = ApiClient.instance.api.getSyncApi();
-      final res = active!.provider == 'odaorg'
-          ? await sync.apiPluginsOdaorgAccountsAccountIdSyncGet(accountId: accountId)
-          : await sync.apiPluginsSchulwareAccountsAccountIdSyncGet(accountId: accountId);
-      final data = res.data as Map<String, dynamic>?;
+      final base = active?.pluginBasePath;
+      if (accountId == null || base == null || base.isEmpty) return;
+      final res = await ApiClient.instance.dio
+          .get<Map<String, dynamic>>('$base/accounts/$accountId/sync');
+      final data = res.data;
       if (!mounted || data == null) return;
       setState(() {
         final last = data['lastSync'];
@@ -71,11 +70,11 @@ class _AccountPageState extends State<AccountPage> {
   Future<void> _loadVersion() async {
     try {
       final active = ActiveAccountService.instance.active;
-      final status = ApiClient.instance.api.getStatusApi();
-      final res = active?.provider == 'odaorg'
-          ? await status.apiPluginsOdaorgStatusGet()
-          : await status.apiPluginsSchulwareStatusGet();
-      final data = res.data as Map<String, dynamic>?;
+      final base = active?.pluginBasePath;
+      if (base == null || base.isEmpty) return;
+      final res =
+          await ApiClient.instance.dio.get<Map<String, dynamic>>('$base/status');
+      final data = res.data;
       if (mounted) setState(() => _version = data?['version']?.toString());
     } catch (_) {/* non-critical */}
   }
@@ -86,7 +85,8 @@ class _AccountPageState extends State<AccountPage> {
   Future<void> _syncNow() async {
     final active = ActiveAccountService.instance.active;
     final accountId = active?.pluginAccountId;
-    if (accountId == null) {
+    final base = active?.pluginBasePath;
+    if (accountId == null || base == null || base.isEmpty) {
       setState(() => _syncMsg = 'No connected account to sync');
       return;
     }
@@ -95,12 +95,7 @@ class _AccountPageState extends State<AccountPage> {
       _syncMsg = null;
     });
     try {
-      final sync = ApiClient.instance.api.getSyncApi();
-      if (active!.provider == 'odaorg') {
-        await sync.apiPluginsOdaorgAccountsAccountIdSyncPost(accountId: accountId);
-      } else {
-        await sync.apiPluginsSchulwareAccountsAccountIdSyncPost(accountId: accountId);
-      }
+      await ApiClient.instance.dio.post<dynamic>('$base/accounts/$accountId/sync');
       await SchoolDataService.instance.refresh();
       await _loadSyncStatus();
       if (mounted) setState(() => _syncMsg = 'Synced just now');

--- a/lib/ui/dashboard/widgets/accounts_sidebar.dart
+++ b/lib/ui/dashboard/widgets/accounts_sidebar.dart
@@ -138,8 +138,7 @@ class AccountsSidebar extends StatelessWidget {
                           children: [
                             for (final s in svc.schools)
                               FTile(
-                                prefix: _SchoolAvatar(
-                                    logoUrl: s.logoUrl, fallbackAsset: s.logoAsset),
+                                prefix: _SchoolAvatar(logoUrl: s.logoUrl),
                                 title: Text(s.name),
                                 subtitle: (s.fullName?.isNotEmpty ?? false)
                                     ? Text(s.fullName!)
@@ -206,19 +205,19 @@ class AccountsSidebar extends StatelessWidget {
   }
 }
 
-/// Rounded-square avatar for a school account, à la Teams' org tiles. Shows
-/// the provider's logo on a muted surface. Today every account is Schulnetz;
-/// once other providers exist this should pick the asset by provider.
+/// Rounded-square avatar for a school account, à la Teams' org tiles. Shows the
+/// school's backend-supplied logo on a muted surface, falling back to a generic
+/// icon — no per-provider asset is bundled in the app.
 class _SchoolAvatar extends StatelessWidget {
   static const double size = 40;
   final String? logoUrl;
-  final String fallbackAsset;
-  const _SchoolAvatar({required this.logoUrl, required this.fallbackAsset});
+  const _SchoolAvatar({required this.logoUrl});
 
   @override
   Widget build(BuildContext context) {
     final colors = context.theme.colors;
-    final fallback = Image.asset(fallbackAsset, fit: BoxFit.contain);
+    final fallback =
+        Icon(Icons.school, size: 22, color: colors.mutedForeground);
     return Container(
       width: size,
       height: size,

--- a/lib/ui/dashboard/widgets/add_school_modal.dart
+++ b/lib/ui/dashboard/widgets/add_school_modal.dart
@@ -1,17 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
+import '../../../config/oidc_config.dart';
 import '../../../domain/school_system.dart';
 import '../../../services/school_systems_service.dart';
 import '../../odaorg/connect_odaorg_screen.dart';
 import '../../schulnetz/connect_account_screen.dart';
-
-/// Local logo assets keyed by school-system key. Backend-advertised systems we
-/// don't yet bundle an asset for fall back to a generic icon.
-const _systemAssets = <String, String>{
-  'schulnetz': 'assets/schoolsystems/schulnetz.webp',
-  'odaorg': 'assets/schoolsystems/odaorg.webp',
-};
 
 /// Full add-school flow: fetch the backend's school-system catalog, show the
 /// picker, then run the chosen system's connect screen. Returns the new account
@@ -120,7 +114,9 @@ class _SystemCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.theme.colors;
     final disabled = onTap == null;
-    final asset = _systemAssets[system.key];
+    final logoUrl = OidcConfig.resolveUrl(system.logoUrl);
+    final fallbackIcon =
+        Icon(Icons.school, size: 48, color: colors.mutedForeground);
     return Opacity(
       opacity: disabled ? 0.5 : 1.0,
       child: SizedBox(
@@ -134,10 +130,13 @@ class _SystemCard extends StatelessWidget {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  if (asset != null)
-                    Image.asset(asset, width: 48, height: 48)
+                  if (logoUrl != null)
+                    Image.network(logoUrl,
+                        width: 48,
+                        height: 48,
+                        errorBuilder: (_, _, _) => fallbackIcon)
                   else
-                    Icon(Icons.school, size: 48, color: colors.mutedForeground),
+                    fallbackIcon,
                   const SizedBox(height: 10),
                   Text(
                     system.displayName,

--- a/lib/ui/documents/documents_page.dart
+++ b/lib/ui/documents/documents_page.dart
@@ -57,14 +57,11 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
   Future<void> _refresh() async {
     final active = ActiveAccountService.instance.active;
     final accountId = active?.pluginAccountId;
-    if (accountId != null) {
+    final base = active?.pluginBasePath;
+    if (accountId != null && base != null && base.isNotEmpty) {
       try {
-        final sync = ApiClient.instance.api.getSyncApi();
-        if (active!.provider == 'odaorg') {
-          await sync.apiPluginsOdaorgAccountsAccountIdSyncPost(accountId: accountId);
-        } else {
-          await sync.apiPluginsSchulwareAccountsAccountIdSyncPost(accountId: accountId);
-        }
+        await ApiClient.instance.dio
+            .post<dynamic>('$base/accounts/$accountId/sync');
       } on DioException catch (e) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/ui/odaorg/connect_odaorg_screen.dart
+++ b/lib/ui/odaorg/connect_odaorg_screen.dart
@@ -1,7 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
-import 'package:schuly_api/schuly_api.dart';
 
 import '../../domain/school_system.dart';
 import '../../services/api_client.dart';
@@ -9,8 +8,9 @@ import '../widgets/dynamic_login_form.dart';
 
 /// Connects an OdaOrg account. Unlike Schulnetz (OAuth/WebView), OdaOrg uses
 /// plain username/password credentials posted to the backend, which then runs
-/// the initial sync. Pops with the new account id (String) on success. The
-/// login inputs are rendered from [system]'s backend-described `loginFields`.
+/// the initial sync. Pops with the new account id (String) on success. Login
+/// inputs and the plugin route both come from [system]'s catalog entry — no
+/// provider is hardcoded.
 class ConnectOdaOrgScreen extends StatefulWidget {
   final SchoolSystem system;
   const ConnectOdaOrgScreen({required this.system, super.key});
@@ -24,8 +24,6 @@ class _ConnectOdaOrgScreenState extends State<ConnectOdaOrgScreen> {
   late final TextEditingController _nameCtrl;
   bool _busy = false;
   String? _error;
-
-  SchulyApi get _api => ApiClient.instance.api;
 
   @override
   void initState() {
@@ -41,18 +39,15 @@ class _ConnectOdaOrgScreenState extends State<ConnectOdaOrgScreen> {
     super.dispose();
   }
 
-  T _expectJson<T>(Response<void> response) {
-    final data = response.data as Object?;
-    if (data is! T) {
-      throw StateError('Expected ${T.toString()}, got ${data.runtimeType}: $data');
-    }
-    return data;
-  }
-
   Future<void> _connect() async {
     final missing = _form.validateRequired();
     if (missing != null) {
       setState(() => _error = missing);
+      return;
+    }
+    final base = widget.system.pluginBasePath;
+    if (base == null || base.isEmpty) {
+      setState(() => _error = 'This system is not configured for account mode');
       return;
     }
     setState(() {
@@ -60,18 +55,20 @@ class _ConnectOdaOrgScreenState extends State<ConnectOdaOrgScreen> {
       _error = null;
     });
     try {
-      final accountsApi = _api.getAccountsApi();
-      final create = await accountsApi.apiPluginsOdaorgAccountsPost(
-        connectOdaOrgRequest: ConnectOdaOrgRequest((b) => b
-          ..username = _form.value('username')
-          ..password = _form.value('password')
-          ..baseUrl = _form.value('baseUrl')
-          ..displayName = _nameCtrl.text.trim()),
+      final dio = ApiClient.instance.dio;
+      final create = await dio.post<Map<String, dynamic>>(
+        '$base/accounts',
+        data: {
+          'username': _form.value('username'),
+          'password': _form.value('password'),
+          'baseUrl': _form.value('baseUrl'),
+          'displayName': _nameCtrl.text.trim(),
+        },
       );
-      final accountId = _expectJson<Map<String, dynamic>>(create)['id'] as String;
+      final accountId = create.data!['id'] as String;
 
       // Kick off the initial sync so data lands before we return.
-      await _api.getSyncApi().apiPluginsOdaorgAccountsAccountIdSyncPost(accountId: accountId);
+      await dio.post<dynamic>('$base/accounts/$accountId/sync');
 
       if (mounted) Navigator.of(context).pop(accountId);
     } on DioException catch (e) {

--- a/lib/ui/schulnetz/connect_account_screen.dart
+++ b/lib/ui/schulnetz/connect_account_screen.dart
@@ -1,7 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
-import 'package:schuly_api/schuly_api.dart';
+
 import '../../domain/school_system.dart';
 import '../../services/api_client.dart';
 import '../widgets/dynamic_login_form.dart';
@@ -10,8 +10,9 @@ import 'schulnetz_oauth_screen.dart';
 /// Connects a Schulnetz school account on the backend.
 ///
 /// Pushed as its own route. Pops with the new account id (`String`) on success
-/// or `null` if the user cancels / a failure occurred. The login inputs are
-/// rendered from [system]'s backend-described `loginFields`.
+/// or `null` if the user cancels / a failure occurred. Login inputs and the
+/// plugin route both come from [system]'s catalog entry — no provider is
+/// hardcoded.
 class ConnectAccountScreen extends StatefulWidget {
   final SchoolSystem system;
   const ConnectAccountScreen({required this.system, super.key});
@@ -25,8 +26,6 @@ class _ConnectAccountScreenState extends State<ConnectAccountScreen> {
   late final TextEditingController _nameCtrl;
   bool _busy = false;
   String? _error;
-
-  SchulyApi get _api => ApiClient.instance.api;
 
   @override
   void initState() {
@@ -42,18 +41,15 @@ class _ConnectAccountScreenState extends State<ConnectAccountScreen> {
     super.dispose();
   }
 
-  T _expectJson<T>(Response<void> response) {
-    final data = response.data as Object?;
-    if (data is! T) {
-      throw StateError('Expected ${T.toString()}, got ${data.runtimeType}: $data');
-    }
-    return data;
-  }
-
   Future<void> _create() async {
     final missing = _form.validateRequired();
     if (missing != null) {
       setState(() => _error = missing);
+      return;
+    }
+    final base = widget.system.pluginBasePath;
+    if (base == null || base.isEmpty) {
+      setState(() => _error = 'This system is not configured for account mode');
       return;
     }
     setState(() {
@@ -61,16 +57,13 @@ class _ConnectAccountScreenState extends State<ConnectAccountScreen> {
       _error = null;
     });
     try {
+      final dio = ApiClient.instance.dio;
       final url = _form.value('baseUrl');
-      final accountsApi = _api.getAccountsApi();
-      final oauthApi = _api.getOAuthApi();
       String? accountId;
 
       // 1. Reuse an existing row if the user is reconnecting the same school.
-      final list = await accountsApi.apiPluginsSchulwareAccountsGet();
-      final accounts =
-          _expectJson<List<dynamic>>(list).cast<Map<String, dynamic>>();
-      for (final a in accounts) {
+      final list = await dio.get<List<dynamic>>('$base/accounts');
+      for (final a in (list.data ?? const []).cast<Map<String, dynamic>>()) {
         if (a['schulnetzBaseUrl'] == url) {
           accountId = a['id'] as String;
           break;
@@ -79,22 +72,21 @@ class _ConnectAccountScreenState extends State<ConnectAccountScreen> {
 
       // 2. Otherwise create a fresh row.
       if (accountId == null) {
-        final create = await accountsApi.apiPluginsSchulwareAccountsPost(
-          connectAccountRequest: ConnectAccountRequest((b) => b
-            ..schulnetzBaseUrl = url
-            ..displayName = _nameCtrl.text.trim()),
+        final create = await dio.post<Map<String, dynamic>>(
+          '$base/accounts',
+          data: {
+            'schulnetzBaseUrl': url,
+            'displayName': _nameCtrl.text.trim(),
+          },
         );
-        accountId = _expectJson<Map<String, dynamic>>(create)['id'] as String;
+        accountId = create.data!['id'] as String;
       }
 
       // 3. Backend hands back the Schulnetz authorize URL + PKCE verifier.
-      final urlRes =
-          await oauthApi.apiPluginsSchulwareAccountsAccountIdAuthOauthUrlGet(
-        accountId: accountId,
-      );
-      final urlData = _expectJson<Map<String, dynamic>>(urlRes);
-      final authorizationUrl = urlData['authorizationUrl'] as String;
-      final codeVerifier = urlData['codeVerifier'] as String;
+      final urlRes = await dio.get<Map<String, dynamic>>(
+          '$base/accounts/$accountId/auth/oauth/url');
+      final authorizationUrl = urlRes.data!['authorizationUrl'] as String;
+      final codeVerifier = urlRes.data!['codeVerifier'] as String;
 
       // 4. Drive Schulnetz's OAuth in a WebView and capture the SSO chain.
       if (!mounted) return;
@@ -113,18 +105,18 @@ class _ConnectAccountScreenState extends State<ConnectAccountScreen> {
 
       // 5. Hand the captured code + storage_state back so the backend can
       //    finish token exchange and replay the SSO chain on refresh.
-      await oauthApi
-          .apiPluginsSchulwareAccountsAccountIdAuthOauthCallbackPost(
-        accountId: accountId,
-        oAuthCallbackRequest: OAuthCallbackRequest((b) => b
-          ..code = result.code
-          ..codeVerifier = codeVerifier
-          ..state = result.state
-          ..contextState = result.contextState
-          ..userAgent = result.userAgent
-          ..webSessionId = result.webSessionId
-          ..webSessionUserId = result.webSessionUserId
-          ..webSessionTransId = result.webSessionTransId),
+      await dio.post<dynamic>(
+        '$base/accounts/$accountId/auth/oauth/callback',
+        data: {
+          'code': result.code,
+          'codeVerifier': codeVerifier,
+          'state': result.state,
+          'contextState': result.contextState,
+          'userAgent': result.userAgent,
+          'webSessionId': result.webSessionId,
+          'webSessionUserId': result.webSessionUserId,
+          'webSessionTransId': result.webSessionTransId,
+        },
       );
 
       if (mounted) Navigator.of(context).pop(accountId);


### PR DESCRIPTION
## Summary

Remove **all** provider/system knowledge from the frontend (follow-up to SchulyBackend #139). The catalog is the sole source of truth.

- `SchoolSystem.pluginBasePath` + `MySchool.pluginBasePath` (from catalog); dropped `MySchool.logoAsset` and the hardcoded default provider.
- Account detection, removal, sync, and status build URLs from `pluginBasePath` via raw `Dio` — no `provider == 'odaorg'` branches, no typed per-plugin client calls.
- Both account-mode connect screens build accounts/OAuth routes from `pluginBasePath`.
- Logos render from the catalog's `logoUrl` (picker + sidebar); the bundled per-key asset map is gone.

The only remaining literals are the `loginMethod` protocol discriminators (`oauth-webview`/`credentials`) — how the app *drives* a login, supplied by the backend. Verified against a locally-run backend; `apigen` regenerates cleanly (committed client left to the release pipeline to avoid baking in dev-only endpoints).

Closes #343