### PR TITLE
Show toasts from the top

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,7 +40,16 @@ class SchulyApp extends StatelessWidget {
             final isDark = mode == ThemeMode.dark ||
                 (mode == ThemeMode.system && platformDark);
             final theme = isDark ? FThemes.zinc.dark : FThemes.zinc.light;
-            return FAnimatedTheme(data: theme, child: child!);
+            // App-wide toaster, anchored at the top so all toasts drop down
+            // from the top edge instead of rising from the bottom.
+            return FAnimatedTheme(
+              data: theme,
+              child: FToaster(
+                style: (s) =>
+                    s.copyWith(toastAlignment: FToastAlignment.topCenter),
+                child: child!,
+              ),
+            );
           },
           home: const RootScreen(),
         );

--- a/lib/ui/documents/documents_page.dart
+++ b/lib/ui/documents/documents_page.dart
@@ -64,8 +64,10 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
             .post<dynamic>('$base/accounts/$accountId/sync');
       } on DioException catch (e) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('Sync failed (${e.response?.statusCode ?? 'network'})')));
+          showFToast(
+            context: context,
+            title: Text('Sync failed (${e.response?.statusCode ?? 'network'})'),
+          );
         }
       } catch (_) {/* fall through to the cache reload */}
     }
@@ -90,8 +92,10 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
       await OpenFilex.open(file.path);
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Could not open document: $e')));
+        showFToast(
+          context: context,
+          title: Text('Could not open document: $e'),
+        );
       }
     } finally {
       if (mounted) setState(() => _downloadingId = null);


### PR DESCRIPTION
## Summary

Make toasts appear from the top. Adds an app-wide `FToaster` anchored at `FToastAlignment.topCenter` (in the `MaterialApp` builder, under the theme) and converts the two Material `SnackBar`s to `showFToast`, so all toasts drop down from the top edge instead of rising from the bottom.

Closes #345