### PR TITLE
Private mode: vault TOTP seed, on-device authenticator, QR scan + silent re-login

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <!-- Scanning the TOTP QR code during private-mode connect. -->
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-feature android:name="android.hardware.camera" android:required="false"/>
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"

--- a/docs/architecture-modes.md
+++ b/docs/architecture-modes.md
@@ -34,14 +34,17 @@ flowchart TB
     SP["ScrapeProxyClient<br/>clean Dio"]
     Stateless[("Backend stateless proxy<br/>/api/plugins/*/stateless/*<br/>[AllowAnonymous] — stores nothing")]
     Keystore[("On-device keystore only")]
+    Auth["Authenticator screen<br/>on-device TOTP from vaulted seed"]
     Catalog --> AnonCat
     Catalog --> Connect
     Connect -->|"token"| TP
     Connect -->|"scrape"| SP
     TP --> Stateless
     SP --> Stateless
-    TP -.->|"token + context saved"| Keystore
+    TP -.->|"token + context + email/password/TOTP seed saved"| Keystore
     SP -.->|"creds saved"| Keystore
+    Keystore -.->|"seed"| Auth
+    Keystore -.->|"silent re-login on expiry"| TP
   end
 
   subgraph SOURCES["School systems (operator-provided)"]

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Schuly uses the camera to scan your two-factor authentication QR code.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/lib/services/private_account_store.dart
+++ b/lib/services/private_account_store.dart
@@ -32,6 +32,11 @@ class PrivateAccount {
   final String? username;
   final String? password;
 
+  /// TOTP seed (normalized base32). Lets Schuly regenerate the second factor
+  /// on-device — for silent re-login and the in-app authenticator. Stored only
+  /// in the device keystore, like every other field here.
+  final String? totpSecret;
+
   const PrivateAccount({
     required this.systemKey,
     required this.loginMethod,
@@ -44,6 +49,7 @@ class PrivateAccount {
     this.userAgent,
     this.username,
     this.password,
+    this.totpSecret,
   });
 
   Map<String, dynamic> toJson() => {
@@ -58,6 +64,7 @@ class PrivateAccount {
         'userAgent': userAgent,
         'username': username,
         'password': password,
+        'totpSecret': totpSecret,
       };
 
   factory PrivateAccount.fromJson(Map<String, dynamic> json) => PrivateAccount(
@@ -72,6 +79,7 @@ class PrivateAccount {
         userAgent: json['userAgent'] as String?,
         username: json['username'] as String?,
         password: json['password'] as String?,
+        totpSecret: json['totpSecret'] as String?,
       );
 }
 

--- a/lib/services/token_proxy_client.dart
+++ b/lib/services/token_proxy_client.dart
@@ -5,6 +5,7 @@ import 'package:dio/dio.dart';
 import '../config/oidc_config.dart';
 import '../domain/private_data.dart';
 import 'private_account_store.dart';
+import 'totp_service.dart';
 
 /// Client for the backend's stateless **token-strategy** proxy used in private
 /// mode. A headless login mints a bearer token (+ refreshable session); data is
@@ -140,31 +141,64 @@ class TokenProxyClient {
     );
   }
 
-  /// Runs a passwordless refresh and returns an account carrying the new token
-  /// and rotated context_state, or null if it isn't possible / failed.
+  /// Re-establishes a token, returning an account carrying the new token and
+  /// rotated context_state, or null if it isn't possible / failed. Tries the
+  /// cheap passwordless refresh first; if that's unavailable or rejected, falls
+  /// back to a full credential re-login from the vaulted email/password/seed —
+  /// Schuly regenerates the OTP itself, so the user is never prompted.
   Future<PrivateAccount?> _refreshAccount(PrivateAccount a) async {
     // Credential logins (ms-entrance) have no captured user-agent — it manages
     // its own — so only context_state is required to replay.
-    if (a.contextState == null) return null;
-    final r = await refresh(
+    if (a.contextState != null) {
+      final r = await refresh(
+        basePath: a.statelessBasePath,
+        baseUrl: a.baseUrl,
+        userAgent: a.userAgent ?? '',
+        contextState: a.contextState!,
+      );
+      if (r.success && r.accessToken != null) return _applied(a, r);
+    }
+    return _credentialRelogin(a);
+  }
+
+  /// Silent re-login from the stored credentials + TOTP seed. Returns null when
+  /// the seed/credentials weren't stored (e.g. an older connection) or login
+  /// failed, leaving the caller to surface a reconnect prompt.
+  Future<PrivateAccount?> _credentialRelogin(PrivateAccount a) async {
+    final email = a.username;
+    final password = a.password;
+    if (email == null || email.isEmpty || password == null || password.isEmpty) {
+      return null;
+    }
+    final r = await login(
       basePath: a.statelessBasePath,
       baseUrl: a.baseUrl,
-      userAgent: a.userAgent ?? '',
-      contextState: a.contextState!,
+      email: email,
+      password: password,
+      // The backend computes the code from the seed; send only the base32.
+      totpSecret: TotpService.secretOf(a.totpSecret),
     );
     if (!r.success || r.accessToken == null) return null;
-    return PrivateAccount(
-      systemKey: a.systemKey,
-      loginMethod: a.loginMethod,
-      baseUrl: a.baseUrl,
-      displayName: a.displayName,
-      statelessBasePath: a.statelessBasePath,
-      accessToken: r.accessToken,
-      refreshToken: r.refreshToken ?? a.refreshToken,
-      contextState: r.contextState ?? a.contextState,
-      userAgent: a.userAgent,
-    );
+    return _applied(a, r);
   }
+
+  /// Builds the rotated account from a refresh/login result, carrying the
+  /// vaulted credentials + seed forward so the next refresh can fall back too.
+  PrivateAccount _applied(PrivateAccount a, PrivateRefreshResult r) =>
+      PrivateAccount(
+        systemKey: a.systemKey,
+        loginMethod: a.loginMethod,
+        baseUrl: a.baseUrl,
+        displayName: a.displayName,
+        statelessBasePath: a.statelessBasePath,
+        accessToken: r.accessToken,
+        refreshToken: r.refreshToken ?? a.refreshToken,
+        contextState: r.contextState ?? a.contextState,
+        userAgent: a.userAgent,
+        username: a.username,
+        password: a.password,
+        totpSecret: a.totpSecret,
+      );
 
   Future<List<T>> _list<T>(
     String path,

--- a/lib/services/totp_service.dart
+++ b/lib/services/totp_service.dart
@@ -1,0 +1,129 @@
+import 'package:otp/otp.dart';
+
+/// A parsed TOTP descriptor. Built from either a bare base32 secret or a full
+/// `otpauth://totp/...` URI (as encoded in an authenticator QR code).
+class TotpConfig {
+  /// Normalized base32 secret — no spaces/dashes, upper-case.
+  final String secret;
+  final int digits;
+  final int period; // seconds
+  final Algorithm algorithm;
+  final String? issuer;
+  final String? account;
+
+  const TotpConfig({
+    required this.secret,
+    this.digits = 6,
+    this.period = 30,
+    this.algorithm = Algorithm.SHA1,
+    this.issuer,
+    this.account,
+  });
+
+  /// Parses [raw], which may be a bare base32 secret or an `otpauth://` URI.
+  /// Returns null when no usable secret can be extracted.
+  static TotpConfig? tryParse(String? raw) {
+    final input = raw?.trim() ?? '';
+    if (input.isEmpty) return null;
+
+    if (input.toLowerCase().startsWith('otpauth://')) {
+      final uri = Uri.tryParse(input);
+      if (uri == null) return null;
+      final secret = normalizeSecret(uri.queryParameters['secret'] ?? '');
+      if (secret.isEmpty) return null;
+
+      // Label is `Issuer:Account` (issuer optional); `issuer` query param wins.
+      String? issuer = uri.queryParameters['issuer'];
+      String? account =
+          uri.pathSegments.isNotEmpty ? uri.pathSegments.last : null;
+      if (account != null && account.contains(':')) {
+        final parts = account.split(':');
+        issuer ??= parts.first.trim();
+        account = parts.sublist(1).join(':').trim();
+      }
+
+      return TotpConfig(
+        secret: secret,
+        digits: int.tryParse(uri.queryParameters['digits'] ?? '') ?? 6,
+        period: int.tryParse(uri.queryParameters['period'] ?? '') ?? 30,
+        algorithm: _algorithm(uri.queryParameters['algorithm']),
+        issuer: (issuer?.isEmpty ?? true) ? null : issuer,
+        account: (account?.isEmpty ?? true) ? null : account,
+      );
+    }
+
+    final secret = normalizeSecret(input);
+    return secret.isEmpty ? null : TotpConfig(secret: secret);
+  }
+
+  /// Strips spaces/dashes and upper-cases — accepts the way authenticators
+  /// display seeds (grouped, lower-case) as well as the raw form.
+  static String normalizeSecret(String s) =>
+      s.replaceAll(RegExp(r'[\s-]'), '').toUpperCase();
+
+  static Algorithm _algorithm(String? a) {
+    switch ((a ?? '').toUpperCase()) {
+      case 'SHA256':
+        return Algorithm.SHA256;
+      case 'SHA512':
+        return Algorithm.SHA512;
+      default:
+        return Algorithm.SHA1;
+    }
+  }
+}
+
+/// A generated code together with how long it stays valid.
+class TotpCode {
+  final String code;
+  final int secondsRemaining;
+  final int period;
+  const TotpCode({
+    required this.code,
+    required this.secondsRemaining,
+    required this.period,
+  });
+
+  /// 1.0 right after a rollover → 0.0 just before the next one.
+  double get fraction => period <= 0 ? 0 : secondsRemaining / period;
+}
+
+/// On-device TOTP (RFC 6238). Lets Schuly act as the authenticator: it both
+/// powers the in-app code display and lets private-mode re-authenticate from a
+/// vaulted seed without the user re-typing a 6-digit code.
+class TotpService {
+  TotpService._();
+
+  /// Current code for [config] at [at] (defaults to now), or null if the secret
+  /// can't be used (e.g. invalid base32).
+  static TotpCode? generate(TotpConfig config, {DateTime? at}) {
+    final now = at ?? DateTime.now();
+    final period = config.period <= 0 ? 30 : config.period;
+    try {
+      final code = OTP.generateTOTPCodeString(
+        config.secret,
+        now.millisecondsSinceEpoch,
+        length: config.digits,
+        interval: period,
+        algorithm: config.algorithm,
+        isGoogle: true,
+      );
+      final epochSeconds = now.millisecondsSinceEpoch ~/ 1000;
+      final remaining = period - (epochSeconds % period);
+      return TotpCode(code: code, secondsRemaining: remaining, period: period);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// The base32 secret extracted from a stored seed/URI (what the backend
+  /// `/login` expects), or null when none can be parsed.
+  static String? secretOf(String? secretOrUri) =>
+      TotpConfig.tryParse(secretOrUri)?.secret;
+
+  /// Convenience: current code string for a stored seed/URI, or null.
+  static String? codeFor(String? secretOrUri, {DateTime? at}) {
+    final config = TotpConfig.tryParse(secretOrUri);
+    return config == null ? null : generate(config, at: at)?.code;
+  }
+}

--- a/lib/ui/dashboard/widgets/accounts_sidebar.dart
+++ b/lib/ui/dashboard/widgets/accounts_sidebar.dart
@@ -4,6 +4,8 @@ import 'package:forui/forui.dart';
 import '../../../domain/my_school.dart';
 import '../../../services/active_account_service.dart';
 import '../../../services/app_mode_service.dart';
+import '../../../services/private_account_store.dart';
+import '../../private/authenticator_screen.dart';
 import '../../settings/settings_screen.dart';
 import 'add_school_modal.dart';
 
@@ -172,6 +174,31 @@ class AccountsSidebar extends StatelessWidget {
                         ),
                         const SizedBox(height: 4),
                       ],
+                      if (isPrivate)
+                        FutureBuilder<PrivateAccount?>(
+                          future: PrivateAccountStore.instance.load(),
+                          builder: (context, snapshot) {
+                            final hasTotp =
+                                snapshot.data?.totpSecret?.isNotEmpty ?? false;
+                            if (!hasTotp) return const SizedBox.shrink();
+                            return Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                FTile(
+                                  prefix: const Icon(FIcons.keyRound),
+                                  title: const Text('Authenticator'),
+                                  onPress: () {
+                                    Navigator.of(context).maybePop();
+                                    parentNavigator.push(MaterialPageRoute(
+                                        builder: (_) =>
+                                            const AuthenticatorScreen()));
+                                  },
+                                ),
+                                const SizedBox(height: 4),
+                              ],
+                            );
+                          },
+                        ),
                       FTile(
                         prefix: const Icon(FIcons.settings),
                         title: const Text('Settings'),

--- a/lib/ui/private/authenticator_screen.dart
+++ b/lib/ui/private/authenticator_screen.dart
@@ -1,0 +1,170 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:forui/forui.dart';
+
+import '../../services/private_account_store.dart';
+import '../../services/totp_service.dart';
+
+/// In-app authenticator for the connected private-mode school. Schuly acts as
+/// the TOTP client: it generates the current code from the vaulted seed and
+/// refreshes it every second, with a countdown and tap-to-copy — so the code is
+/// available for use elsewhere, not just for Schuly's own re-login.
+class AuthenticatorScreen extends StatefulWidget {
+  const AuthenticatorScreen({super.key});
+
+  @override
+  State<AuthenticatorScreen> createState() => _AuthenticatorScreenState();
+}
+
+class _AuthenticatorScreenState extends State<AuthenticatorScreen> {
+  Timer? _timer;
+  bool _loading = true;
+  TotpConfig? _config;
+  String _title = 'Authenticator';
+  TotpCode? _code;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final account = await PrivateAccountStore.instance.load();
+    final config = TotpConfig.tryParse(account?.totpSecret);
+    if (!mounted) return;
+    setState(() {
+      _config = config;
+      _title = account?.displayName ?? 'Authenticator';
+      _code = config == null ? null : TotpService.generate(config);
+      _loading = false;
+    });
+    if (config != null) {
+      _timer = Timer.periodic(const Duration(seconds: 1), (_) => _tick());
+    }
+  }
+
+  void _tick() {
+    final config = _config;
+    if (config == null) return;
+    setState(() => _code = TotpService.generate(config));
+  }
+
+  Future<void> _copy() async {
+    final code = _code?.code;
+    if (code == null) return;
+    await Clipboard.setData(ClipboardData(text: code));
+    if (!mounted) return;
+    showFToast(context: context, title: const Text('Code copied'));
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  /// `123456` → `123 456` for readability; leaves other lengths untouched.
+  String _format(String code) {
+    if (code.length != 6) return code;
+    return '${code.substring(0, 3)} ${code.substring(3)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+
+    return FScaffold(
+      header: FHeader.nested(
+        title: const Text('Authenticator'),
+        prefixes: [
+          FHeaderAction.back(onPress: () => Navigator.of(context).pop()),
+        ],
+      ),
+      child: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _config == null
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Text(
+                      'No authenticator secret is stored for this connection. '
+                      'Reconnect and scan or enter your TOTP code to enable it.',
+                      textAlign: TextAlign.center,
+                      style: typography.sm
+                          .copyWith(color: colors.mutedForeground),
+                    ),
+                  ),
+                )
+              : _content(context),
+    );
+  }
+
+  Widget _content(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+    final code = _code;
+    final fraction = code?.fraction ?? 0;
+    final low = (code?.secondsRemaining ?? 0) <= 5;
+    final accent = low ? colors.destructive : colors.primary;
+
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            _title,
+            textAlign: TextAlign.center,
+            style: typography.lg.copyWith(fontWeight: FontWeight.w600),
+          ),
+          Text(
+            'Tap the code to copy',
+            textAlign: TextAlign.center,
+            style: typography.sm.copyWith(color: colors.mutedForeground),
+          ),
+          const SizedBox(height: 24),
+          GestureDetector(
+            onTap: _copy,
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+              decoration: BoxDecoration(
+                color: colors.secondary,
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Text(
+                code == null ? '------' : _format(code.code),
+                textAlign: TextAlign.center,
+                style: typography.xl4.copyWith(
+                  color: accent,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 4,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: fraction,
+              minHeight: 6,
+              backgroundColor: colors.muted,
+              valueColor: AlwaysStoppedAnimation(accent),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Refreshes in ${code?.secondsRemaining ?? 0}s',
+            textAlign: TextAlign.center,
+            style: typography.sm.copyWith(color: colors.mutedForeground),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/private/private_connect_screen.dart
+++ b/lib/ui/private/private_connect_screen.dart
@@ -6,7 +6,9 @@ import '../../domain/school_system.dart';
 import '../../services/private_account_store.dart';
 import '../../services/scrape_proxy_client.dart';
 import '../../services/token_proxy_client.dart';
+import '../../services/totp_service.dart';
 import '../widgets/dynamic_login_form.dart';
+import 'totp_scan_screen.dart';
 
 /// Generic private-mode connect screen. Renders the chosen [system]'s
 /// backend-described `loginFields` and connects headlessly — no WebView. The
@@ -85,18 +87,24 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
 
   Future<void> _connectToken(
       String baseUrl, String name, String basePath) async {
-    final totp = _form.value('totp');
+    final email = _form.value('email');
+    final password = _form.value('password');
+    // Accept a typed base32 secret or a scanned otpauth:// URI; normalize to the
+    // base32 the backend expects, and stash it for on-device generation.
+    final totpSecret = TotpService.secretOf(_form.value('totp'));
     final res = await TokenProxyClient.instance.login(
       basePath: basePath,
       baseUrl: baseUrl,
-      email: _form.value('email'),
-      password: _form.value('password'),
-      totpSecret: totp.isEmpty ? null : totp,
+      email: email,
+      password: password,
+      totpSecret: totpSecret,
     );
     if (!res.success || res.accessToken == null) {
       setState(() => _error = res.message ?? 'Login failed');
       return;
     }
+    // Persist credentials + seed alongside the token so Schuly can silently
+    // re-login and act as the authenticator. Kept in the device keystore only.
     await PrivateAccountStore.instance.save(PrivateAccount(
       systemKey: _system.key,
       loginMethod: _system.loginMethod,
@@ -106,8 +114,22 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
       accessToken: res.accessToken,
       refreshToken: res.refreshToken,
       contextState: res.contextState,
+      username: email,
+      password: password,
+      totpSecret: totpSecret,
     ));
     if (mounted) Navigator.of(context).pop(true);
+  }
+
+  /// Opens the QR scanner and writes the scanned `otpauth://` URI / secret back
+  /// into the TOTP field.
+  Future<void> _scanTotp(String fieldKey) async {
+    final scanned = await Navigator.of(context).push<String>(
+      MaterialPageRoute(builder: (_) => const TotpScanScreen()),
+    );
+    if (scanned != null && scanned.isNotEmpty) {
+      _form.controllerFor(fieldKey).text = scanned;
+    }
   }
 
   Future<void> _connectScrape(
@@ -143,7 +165,7 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
             'Private mode keeps everything on this device — no account, '
             'nothing stored on a server.',
           ),
-          DynamicLoginForm(controller: _form),
+          DynamicLoginForm(controller: _form, onScanField: _scanTotp),
           FTextField(
             control: FTextFieldControl.managed(controller: _nameCtrl),
             label: const Text('Display Name'),

--- a/lib/ui/private/totp_scan_screen.dart
+++ b/lib/ui/private/totp_scan_screen.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+import '../../services/totp_service.dart';
+
+/// Scans an authenticator QR code and returns the raw payload (an
+/// `otpauth://` URI, or a bare secret) to the caller. Only codes that parse as
+/// a usable TOTP are accepted — other QR codes are ignored so the camera keeps
+/// scanning. Pops with the scanned string, or null if cancelled.
+///
+/// The [MobileScanner] manages its own camera controller lifecycle.
+class TotpScanScreen extends StatefulWidget {
+  const TotpScanScreen({super.key});
+
+  @override
+  State<TotpScanScreen> createState() => _TotpScanScreenState();
+}
+
+class _TotpScanScreenState extends State<TotpScanScreen> {
+  bool _handled = false;
+
+  void _onDetect(BarcodeCapture capture) {
+    if (_handled) return;
+    for (final barcode in capture.barcodes) {
+      final raw = barcode.rawValue;
+      if (raw == null || TotpConfig.tryParse(raw) == null) continue;
+      _handled = true;
+      Navigator.of(context).pop(raw);
+      return;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    return FScaffold(
+      header: FHeader.nested(
+        title: const Text('Scan TOTP code'),
+        prefixes: [
+          FHeaderAction.back(onPress: () => Navigator.of(context).pop()),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        spacing: 16,
+        children: [
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: MobileScanner(onDetect: _onDetect),
+            ),
+          ),
+          Text(
+            'Point the camera at the authenticator QR code shown when you set '
+            'up two-factor authentication.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: colors.mutedForeground),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/dynamic_login_form.dart
+++ b/lib/ui/widgets/dynamic_login_form.dart
@@ -46,7 +46,23 @@ class DynamicLoginFormController {
 /// backend, not the app, decides what the login form shows.
 class DynamicLoginForm extends StatelessWidget {
   final DynamicLoginFormController controller;
-  const DynamicLoginForm({required this.controller, super.key});
+
+  /// Invoked when the user taps "Scan QR code" on a TOTP field. Receives the
+  /// field key; the caller scans and writes the result back into the
+  /// controller. When null, no scan affordance is shown.
+  final Future<void> Function(String fieldKey)? onScanField;
+
+  const DynamicLoginForm({
+    required this.controller,
+    this.onScanField,
+    super.key,
+  });
+
+  /// A field that carries a TOTP seed — obscured and offered a QR scanner.
+  /// Detected by an explicit `totp` type or the conventional `totp` key, so the
+  /// backend catalog can opt in without the app hardcoding a provider.
+  static bool _isTotp(SchoolSystemLoginField f) =>
+      f.type == 'totp' || f.key.toLowerCase() == 'totp';
 
   @override
   Widget build(BuildContext context) {
@@ -56,17 +72,64 @@ class DynamicLoginForm extends StatelessWidget {
       spacing: 16,
       children: [
         for (final field in controller.fields)
-          FTextField(
-            control: FTextFieldControl.managed(
+          if (_isTotp(field))
+            _TotpField(
               controller: controller.controllerFor(field.key),
+              field: field,
+              onScan: onScanField == null
+                  ? null
+                  : () => onScanField!(field.key),
+            )
+          else
+            FTextField(
+              control: FTextFieldControl.managed(
+                controller: controller.controllerFor(field.key),
+              ),
+              label: Text(field.label),
+              hint: field.placeholder,
+              obscureText: field.type == 'password',
+              keyboardType: field.type == 'url'
+                  ? TextInputType.url
+                  : TextInputType.text,
+              autocorrect: false,
             ),
-            label: Text(field.label),
-            hint: field.placeholder,
-            obscureText: field.type == 'password',
-            keyboardType: field.type == 'url'
-                ? TextInputType.url
-                : TextInputType.text,
-            autocorrect: false,
+      ],
+    );
+  }
+}
+
+/// A TOTP seed input: obscured text plus an optional "Scan QR code" button.
+class _TotpField extends StatelessWidget {
+  final TextEditingController controller;
+  final SchoolSystemLoginField field;
+  final VoidCallback? onScan;
+
+  const _TotpField({
+    required this.controller,
+    required this.field,
+    this.onScan,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      spacing: 8,
+      children: [
+        FTextField(
+          control: FTextFieldControl.managed(controller: controller),
+          label: Text(field.label),
+          hint: field.placeholder ?? 'Secret or otpauth:// URI',
+          obscureText: true,
+          autocorrect: false,
+        ),
+        if (onScan != null)
+          FButton(
+            style: FButtonStyle.outline(),
+            prefix: const Icon(FIcons.scanQrCode),
+            onPress: onScan,
+            child: const Text('Scan QR code'),
           ),
       ],
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,10 @@ dependencies:
   forui_assets: ^0.17.1
   path_provider: ^2.1.2
   open_filex: ^4.5.0
+  # On-device TOTP: generate the second factor from a vaulted seed.
+  otp: ^3.1.4
+  # QR scanning to capture the TOTP seed.
+  mobile_scanner: ^5.2.3
 
 dev_dependencies:
   flutter_test:

--- a/test/totp_service_test.dart
+++ b/test/totp_service_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otp/otp.dart';
+import 'package:schuly/services/totp_service.dart';
+
+void main() {
+  group('TotpConfig.tryParse', () {
+    test('returns null for empty / null input', () {
+      expect(TotpConfig.tryParse(null), isNull);
+      expect(TotpConfig.tryParse('   '), isNull);
+    });
+
+    test('parses a bare base32 secret with defaults', () {
+      final config = TotpConfig.tryParse('jbsw y3dp-ehpk 3pxp');
+      expect(config, isNotNull);
+      expect(config!.secret, 'JBSWY3DPEHPK3PXP');
+      expect(config.digits, 6);
+      expect(config.period, 30);
+      expect(config.algorithm, Algorithm.SHA1);
+    });
+
+    test('parses a full otpauth URI including issuer/digits/period/algorithm', () {
+      final config = TotpConfig.tryParse(
+        'otpauth://totp/Example?secret=JBSWY3DPEHPK3PXP&issuer=Acme'
+        '&digits=8&period=60&algorithm=SHA256',
+      );
+      expect(config, isNotNull);
+      expect(config!.secret, 'JBSWY3DPEHPK3PXP');
+      expect(config.digits, 8);
+      expect(config.period, 60);
+      expect(config.algorithm, Algorithm.SHA256);
+      expect(config.issuer, 'Acme');
+    });
+
+    test('splits an Issuer:Account label when no issuer param is present', () {
+      final config = TotpConfig.tryParse(
+        'otpauth://totp/Schulnetz:alice@example.com?secret=JBSWY3DPEHPK3PXP',
+      );
+      expect(config!.issuer, 'Schulnetz');
+      expect(config.account, 'alice@example.com');
+    });
+
+    test('returns null when the URI has no secret', () {
+      expect(TotpConfig.tryParse('otpauth://totp/Example?issuer=Acme'), isNull);
+    });
+  });
+
+  group('TotpService.generate', () {
+    final config = TotpConfig.tryParse('JBSWY3DPEHPK3PXP')!;
+
+    test('produces a code of the configured length, all digits', () {
+      final result = TotpService.generate(config, at: DateTime.now());
+      expect(result, isNotNull);
+      expect(result!.code.length, 6);
+      expect(RegExp(r'^\d+$').hasMatch(result.code), isTrue);
+    });
+
+    test('is deterministic for a fixed instant', () {
+      final at = DateTime.fromMillisecondsSinceEpoch(1234567890000);
+      expect(
+        TotpService.generate(config, at: at)!.code,
+        TotpService.generate(config, at: at)!.code,
+      );
+    });
+
+    test('reports the seconds left in the current 30s window', () {
+      // epoch second 59 → 59 % 30 == 29 → 1 second until rollover.
+      final at = DateTime.fromMillisecondsSinceEpoch(59000);
+      final result = TotpService.generate(config, at: at)!;
+      expect(result.secondsRemaining, 1);
+      expect(result.period, 30);
+      expect(result.fraction, closeTo(1 / 30, 1e-9));
+    });
+  });
+
+  group('TotpService.secretOf', () {
+    test('extracts the base32 secret from an otpauth URI', () {
+      expect(
+        TotpService.secretOf(
+          'otpauth://totp/X?secret=JBSWY3DPEHPK3PXP&issuer=Y',
+        ),
+        'JBSWY3DPEHPK3PXP',
+      );
+    });
+
+    test('normalizes a spaced / lower-case bare secret', () {
+      expect(TotpService.secretOf('jbsw y3dp'), 'JBSWY3DP');
+    });
+  });
+}


### PR DESCRIPTION
Makes Schuly own the second factor for `token`-strategy private connections.

- **Vault** — `PrivateAccount` now persists the TOTP seed (normalized base32) plus email/password in the OS keystore.
- **On-device generator** — `TotpService` (RFC 6238) parses a bare base32 seed or a full `otpauth://` URI and produces the current code.
- **Authenticator screen** — live rotating 6-digit code with countdown + tap-to-copy, reachable from the accounts sidebar when a seed is stored.
- **QR scan** — `mobile_scanner` captures the seed during connect; only payloads that parse as a usable TOTP are accepted.
- **Silent re-login** — when `contextState` refresh fails, `TokenProxyClient` re-authenticates from the vaulted credentials + seed with no prompts.
- Camera permission added (Android manifest, iOS `NSCameraUsageDescription`); unit tests for parsing/generation.

`pubspec.lock` is regenerated by CI's `flutter pub get` (added `otp`, `mobile_scanner`).

Closes #355