### PR TITLE
CI: bump Flutter pin to 3.44.x for Dart ^3.10.0

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.35.x'
+          flutter-version: '3.44.x'
           channel: 'stable'
           cache: true
 
@@ -114,7 +114,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.35.x'
+          flutter-version: '3.44.x'
           channel: 'stable'
           cache: true
 


### PR DESCRIPTION
Bumps both `flutter-version` pins in `build-and-release.yml` from `3.35.x` (Dart 3.9.2) to `3.44.x` (Dart ≥3.10), so `flutter pub get` can resolve the project's `sdk: ^3.10.0` constraint. Verified locally with Flutter 3.44.2 / Dart 3.12.2: `pub get` resolves and `flutter analyze` is clean.

Closes #357