### PR TITLE
Sourced OIDC settings from the backend instead of hardcoding the provider

### DIFF
--- a/lib/config/oidc_config.dart
+++ b/lib/config/oidc_config.dart
@@ -1,19 +1,35 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Resolved OIDC settings for the active backend. Everything except the backend
+/// base URL is discovered at runtime — the backend's `/api/app` provides the
+/// authority, client id, scope and redirect uri, and the provider's OIDC
+/// discovery document provides the authorize/token endpoints. Nothing
+/// provider-specific (Keycloak vs Pocket ID vs …) is hardcoded.
+class OidcSettings {
+  final String authority;
+  final String clientId;
+  final String scope;
+  final String redirectUri;
+  final String authorizationEndpoint;
+  final String tokenEndpoint;
+
+  const OidcSettings({
+    required this.authority,
+    required this.clientId,
+    required this.scope,
+    required this.redirectUri,
+    required this.authorizationEndpoint,
+    required this.tokenEndpoint,
+  });
+
+  /// Deep-link scheme the provider redirects back to (e.g. `schulytest`),
+  /// derived from [redirectUri] so the app never hardcodes it.
+  String get callbackScheme => Uri.parse(redirectUri).scheme;
+}
+
 class OidcConfig {
-  static const authority = 'https://auth.gaggao.com';
-  static const clientId = 'fe2e0db0-69e3-48e3-845c-561f7a36d280';
-  // `offline_access` is required for Pocket ID to issue a refresh token —
-  // without it the silent token refresh has nothing to work with and the user
-  // gets bounced to re-login the moment the access token expires.
-  static const scope = 'openid profile email groups picture offline_access';
-
-  // Custom scheme deep link. Pocket ID redirects here after login; Android
-  // routes it back to the app via the schulytest:// intent filter, so the
-  // user lands in the real Chrome (full passkey support) and returns to the
-  // app on success. Scheme intentionally does NOT mirror the package id so
-  // dev and prod flavors can coexist.
-  static const redirectUri = 'schulytest://callback';
-  static const callbackScheme = 'schulytest';
-
   // Backend base URL. Override per build — never hardcode a machine IP here:
   //   flutter build apk --dart-define=BACKEND_BASE_URL=http://<dev-box-lan-ip>:5033
   // Defaults to localhost: use `adb reverse tcp:5033 tcp:5033` over USB, or
@@ -23,8 +39,48 @@ class OidcConfig {
     defaultValue: 'http://localhost:5033',
   );
 
-  static const tokenEndpoint = '$authority/api/oidc/token';
-  static const authorizationEndpoint = '$authority/authorize';
+  static OidcSettings? _settings;
+  static Future<OidcSettings>? _loading;
+
+  /// Loads (once) and caches the OIDC settings from the backend. Safe to call
+  /// from multiple places concurrently — the in-flight load is shared, and a
+  /// failed load is not cached so the next call retries.
+  static Future<OidcSettings> settings() {
+    final cached = _settings;
+    if (cached != null) return Future<OidcSettings>.value(cached);
+    return _loading ??= _load().then((s) {
+      _settings = s;
+      _loading = null;
+      return s;
+    }, onError: (Object e) {
+      _loading = null;
+      throw e;
+    });
+  }
+
+  static Future<OidcSettings> _load() async {
+    final app = await _getJson('$backendBaseUrl/api/app');
+    final authority =
+        (app['authority'] as String).replaceAll(RegExp(r'/+$'), '');
+    final disco = await _getJson('$authority/.well-known/openid-configuration');
+    return OidcSettings(
+      authority: authority,
+      clientId: app['clientId'] as String,
+      scope: (app['scope'] as String?) ??
+          'openid profile email groups picture offline_access',
+      redirectUri: (app['redirectUri'] as String?) ?? 'schulytest://callback',
+      authorizationEndpoint: disco['authorization_endpoint'] as String,
+      tokenEndpoint: disco['token_endpoint'] as String,
+    );
+  }
+
+  static Future<Map<String, dynamic>> _getJson(String url) async {
+    final r = await http.get(Uri.parse(url));
+    if (r.statusCode != 200) {
+      throw Exception('GET $url failed (${r.statusCode})');
+    }
+    return jsonDecode(r.body) as Map<String, dynamic>;
+  }
 
   /// Resolves a backend-supplied URL: absolute (http…) is used as-is, a
   /// root-relative path (/api/avatars/…) is prefixed with [backendBaseUrl],

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -73,14 +73,15 @@ class AuthService {
   /// 4. Await the first incoming [OidcConfig.redirectUri] deep link.
   /// 5. Exchange the auth code for tokens.
   static Future<AuthTokens> signIn() async {
+    final cfg = await OidcConfig.settings();
     final (verifier, challenge) = _generatePkce();
     final state = DateTime.now().microsecondsSinceEpoch.toString();
-    final authorizeUrl = Uri.parse(OidcConfig.authorizationEndpoint).replace(
+    final authorizeUrl = Uri.parse(cfg.authorizationEndpoint).replace(
       queryParameters: {
         'response_type': 'code',
-        'client_id': OidcConfig.clientId,
-        'redirect_uri': OidcConfig.redirectUri,
-        'scope': OidcConfig.scope,
+        'client_id': cfg.clientId,
+        'redirect_uri': cfg.redirectUri,
+        'scope': cfg.scope,
         'state': state,
         'code_challenge': challenge,
         'code_challenge_method': 'S256',
@@ -90,7 +91,7 @@ class AuthService {
     final completer = Completer<Uri>();
     late final StreamSubscription<Uri> sub;
     sub = _appLinks.uriLinkStream.listen((uri) {
-      if (uri.scheme == OidcConfig.callbackScheme && !completer.isCompleted) {
+      if (uri.scheme == cfg.callbackScheme && !completer.isCompleted) {
         completer.complete(uri);
       }
     });
@@ -130,14 +131,15 @@ class AuthService {
     required String code,
     required String codeVerifier,
   }) async {
+    final cfg = await OidcConfig.settings();
     final response = await http.post(
-      Uri.parse(OidcConfig.tokenEndpoint),
+      Uri.parse(cfg.tokenEndpoint),
       headers: {'Content-Type': 'application/x-www-form-urlencoded'},
       body: {
         'grant_type': 'authorization_code',
         'code': code,
-        'client_id': OidcConfig.clientId,
-        'redirect_uri': OidcConfig.redirectUri,
+        'client_id': cfg.clientId,
+        'redirect_uri': cfg.redirectUri,
         'code_verifier': codeVerifier,
       },
     );
@@ -184,13 +186,14 @@ class AuthService {
     final refreshToken = await getRefreshToken();
     if (refreshToken == null) return null;
     try {
+      final cfg = await OidcConfig.settings();
       final response = await http.post(
-        Uri.parse(OidcConfig.tokenEndpoint),
+        Uri.parse(cfg.tokenEndpoint),
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         body: {
           'grant_type': 'refresh_token',
           'refresh_token': refreshToken,
-          'client_id': OidcConfig.clientId,
+          'client_id': cfg.clientId,
         },
       );
       if (response.statusCode != 200) return null;


### PR DESCRIPTION
Resolves the OIDC authority, client id, scope, redirect uri and authorize/token endpoints at runtime from /api/app plus the provider's discovery document, instead of hardcoding Pocket ID. The app now follows whatever IdP the backend advertises (Keycloak), with nothing provider-specific baked in.

Closes #361