### PR TITLE
Add documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# Schuly documentation
+
+Schuly is a Flutter mobile app for accessing school data (grades, exams, agenda,
+absences) from Schulnetz-based systems. It runs in two modes — an **account mode**
+backed by [SchulyBackend](https://github.com/schulydev/SchulyBackend) over OIDC, and
+a **private / secure mode** that keeps credentials on-device and talks only to
+anonymous stateless proxy endpoints. The UI is built with [Forui](https://forui.dev).
+
+## Contents
+
+| Doc | What it covers |
+| --- | --- |
+| [Architecture: app modes](architecture-modes.md) | Account vs private mode, where data lives, the connect flow |
+| [Development setup](setup/development.md) | Flutter SDK, bun task runner, running the dev/prod flavors, analyze/test/format |
+| [Build & release](setup/build-and-release.md) | Release APKs, iOS build, adb install, app-icon regeneration |
+| [API client](api-client.md) | How `lib/api/` is generated and how to regenerate it |
+| [Contributing](contributing.md) | The enforced issue → branch → PR workflow and label taxonomy |
+
+## Quick start
+
+```sh
+bun run clean   # flutter clean && flutter pub get
+bun run dev     # run the dev flavor on a connected device/emulator
+```
+
+See [Development setup](setup/development.md) for prerequisites.

--- a/docs/api-client.md
+++ b/docs/api-client.md
@@ -1,0 +1,41 @@
+# API client (`lib/api/`)
+
+The Dart API client at `lib/api/` is **generated**, not hand-written. It is produced
+by [openapi-generator](https://openapi-generator.tech) (`dart-dio` generator) from
+[SchulyBackend](https://github.com/schulydev/SchulyBackend)'s OpenAPI 3.0 spec, served
+at `/openapi/v1.json`. The app depends on it as a local package via a `path:` reference
+in `pubspec.yaml` (`schuly_api`).
+
+## Regenerating
+
+The backend must be running and reachable at `http://localhost:5033`. Then:
+
+```sh
+bun run apigen        # regenerate from http://localhost:5033/openapi/v1.json
+bun run apigen:local  # same target, explicit local alias
+```
+
+`apigen` chains three steps:
+
+1. **Generate** — `openapi-generator-cli generate -g dart-dio` against the live spec
+   (`http://localhost:5033/openapi/v1.json`), output into `lib/api`
+   (`pubName=schuly_api`, `pubLibrary=schuly_api`).
+2. **Patch** (`apigen:patch`) — rewrites `lib/api/pubspec.yaml`'s SDK constraint. The
+   generator resets it to `'>=2.18.0 <4.0.0'`, which breaks the build due to a
+   part-file language-version mismatch. The patch replaces it with `^3.10.0`.
+   Implemented as a `bun -e` one-liner so it runs identically on any shell.
+3. **Build** (`apigen:build`) — `cd lib/api && dart pub get && dart run build_runner
+   build --delete-conflicting-outputs` to produce the `.g.dart` serialization code.
+
+## Notes
+
+- **`openapi.json` is gitignored** — always regenerate from the running backend rather
+  than committing a local copy of the spec.
+- `lib/api/**` is **excluded from `flutter analyze`** (see `analysis_options.yaml`), so
+  generator output never trips lint checks.
+- The generated `.g.dart` files are produced by `build_runner`; if they go stale,
+  re-run `bun run apigen` (or just the `apigen:build` step) to refresh them.
+
+## Related
+
+- [Development setup](setup/development.md) — installing deps, running the app.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,72 @@
+# Contributing
+
+The contribution workflow is **enforced** — follow it exactly.
+
+## Hard rules
+
+- **Never work on `main`.** All changes go through an issue → branch → PR cycle.
+- **No AI / Claude attribution, ever.** Commit messages, PR titles/bodies, and issue
+  text must not mention AI, Claude, or any assistant, and must not include
+  `Co-Authored-By` / "Generated with" trailers.
+- **No test plans in PRs.** The PR body is **Summary + `Closes #<issue>` only**.
+- **Prefer CLI generators** whenever one exists (`gh issue create`, `gh pr create`,
+  etc.) over manual steps.
+
+## Workflow
+
+1. **Create a labeled issue** describing the change.
+
+   ```sh
+   gh issue create --title "..." --body "..." --label <label>
+   ```
+
+2. **Branch off `main`** using the issue number and a `PascalCase` slug:
+
+   ```sh
+   git switch -c feature/<issue#>_PascalCase   # new functionality
+   git switch -c fix/<issue#>_PascalCase       # bug fix
+   ```
+
+3. **Commit** with a short imperative subject (e.g. `Add agenda filter`).
+
+4. **Open a PR** (labeled) whose body is only a short summary and the closing
+   reference:
+
+   ```sh
+   gh pr create --title "..." --label <label> --body "Summary of the change.
+
+   Closes #<issue>"
+   ```
+
+5. **Squash-merge and delete the branch** once approved.
+
+## Branch naming
+
+| Kind | Pattern | Example |
+| --- | --- | --- |
+| Feature | `feature/<issue#>_PascalCase` | `feature/123_AgendaFilter` |
+| Fix | `fix/<issue#>_PascalCase` | `fix/124_LoginCrash` |
+
+## Labels
+
+Apply the appropriate label to both the issue and the PR:
+
+| Label | Use for |
+| --- | --- |
+| `bug` | Defect reports |
+| `enhancement` | Improvements to existing behavior |
+| `feature` | New functionality |
+| `refactor` | Internal restructuring, no behavior change |
+| `CI/CD` | Pipeline / workflow changes |
+| `dependencies` | Dependency bumps |
+| `documentation` | Docs-only changes |
+
+## Before opening a PR
+
+Run the quality checks (see [Development setup](setup/development.md)):
+
+```sh
+bun run analyze
+bun run test
+bun run format
+```

--- a/docs/setup/build-and-release.md
+++ b/docs/setup/build-and-release.md
@@ -1,0 +1,74 @@
+# Build & release
+
+Producing installable artifacts for the Schuly app. All commands are `package.json`
+scripts run via bun — see [Development setup](development.md) for prerequisites and a
+flavor overview.
+
+## Release APKs
+
+```sh
+bun run build:apk:dev    # flutter build apk --flavor dev  --release
+bun run build:apk:prod   # flutter build apk --flavor prod --release
+```
+
+| Flavor | Application ID | Display name |
+| --- | --- | --- |
+| `dev` | `com.schuly.app.dev` (version name suffix `-DEV`) | **Schuly DEV** |
+| `prod` | `com.schuly.app` | **Schuly** |
+
+The two flavors install side by side, so a dev build never overwrites a prod build
+on the same device.
+
+### Pointing a dev build at a custom backend
+
+```sh
+BACKEND_BASE_URL=https://example.test bun run build:apk:dev:url
+```
+
+`build:apk:dev:url` forwards `$BACKEND_BASE_URL` through `--dart-define=BACKEND_BASE_URL`.
+
+## iOS build
+
+```sh
+bun run build:ios   # flutter build ios --flavor prod --no-codesign
+```
+
+Builds the `prod` flavor without code signing (sign separately in Xcode / your
+signing pipeline).
+
+## Install over adb
+
+Build and install the release APK onto the currently connected adb target:
+
+```sh
+bun run install:dev    # build dev  APK, then flutter install --flavor dev
+bun run install:prod   # build prod APK, then flutter install --flavor prod
+```
+
+When running against a locally hosted backend over USB, reverse the backend port
+first so the device can reach `localhost:5033`:
+
+```sh
+bun run adb:reverse        # adb reverse tcp:5033 tcp:5033
+bun run install:dev:usb    # adb:reverse + install:dev
+```
+
+To install a dev build pointed at a custom backend URL:
+
+```sh
+BACKEND_BASE_URL=https://example.test bun run install:dev:url
+```
+
+## App icons
+
+The launcher icon is generated from `assets/app_icon.png` via `flutter_launcher_icons`
+(Android + iOS, configured in `pubspec.yaml`). After changing the source image:
+
+```sh
+bun run icons   # dart run flutter_launcher_icons
+```
+
+## Related
+
+- [Development setup](development.md) — SDK versions, running the app.
+- [API client](../api-client.md) — regenerating the generated client before a build.

--- a/docs/setup/development.md
+++ b/docs/setup/development.md
@@ -1,0 +1,80 @@
+# Development setup
+
+Local environment setup for working on the Schuly Flutter app.
+
+## Prerequisites
+
+| Tool | Version | Notes |
+| --- | --- | --- |
+| Flutter SDK | `3.44.x` | Pinned in CI (`subosito/flutter-action`). Bundles the matching Dart SDK. |
+| Dart SDK | `^3.10.0` | Comes with Flutter `3.44.x`; also the `environment.sdk` constraint in `pubspec.yaml`. |
+| bun | `latest` | Used purely as a task runner for the `package.json` scripts. It does **not** pull in a Node toolchain — it only dispatches commands. |
+| Android SDK / Xcode | — | Standard Flutter mobile toolchain for building/running on Android or iOS. |
+
+Verify the Flutter toolchain with:
+
+```sh
+flutter doctor
+```
+
+## Tasks (preferred)
+
+All common workflows are wrapped as `package.json` scripts so they're invoked the
+same way from any shell. Always prefer `bun run <script>` over the raw command.
+
+```sh
+bun run dev        # flutter run --flavor dev
+bun run prod       # flutter run --flavor prod
+bun run analyze    # flutter analyze
+bun run test       # flutter test
+bun run format     # dart format lib
+bun run clean      # flutter clean && flutter pub get
+```
+
+## Getting dependencies
+
+```sh
+bun run clean
+```
+
+This runs `flutter clean && flutter pub get`. The app depends on the local generated
+API package at `lib/api/` (referenced via `path:` in `pubspec.yaml`) — see
+[API client](../api-client.md) if you need to regenerate it.
+
+## Running the app
+
+Start an emulator or connect a device, then run one of the flavors:
+
+```sh
+bun run dev     # development flavor
+bun run prod    # production flavor
+```
+
+### Flavors
+
+The app defines an `environment` flavor dimension (Android: `productFlavors` in
+`android/app/build.gradle.kts`):
+
+| Flavor | Application ID | Display name |
+| --- | --- | --- |
+| `dev` | `com.schuly.app.dev` (`.dev` suffix, version name suffix `-DEV`) | **Schuly DEV** |
+| `prod` | `com.schuly.app` | **Schuly** |
+
+Because the IDs differ, the dev and prod builds install side by side on the same
+device. Use `dev` for day-to-day work and `prod` to validate release behavior.
+
+## Quality checks before pushing
+
+```sh
+bun run analyze   # static analysis
+bun run test      # unit/widget tests
+bun run format    # auto-format lib/
+```
+
+The generated client at `lib/api/**` is excluded from `flutter analyze` (see
+`analysis_options.yaml`).
+
+## Related
+
+- [Build & release](build-and-release.md) — release APKs, iOS, adb install, icons.
+- [Contributing](../contributing.md) — branch/PR workflow.


### PR DESCRIPTION
Adds a `docs/` folder: an index, development setup, build & release, API client regeneration, and the enforced contribution workflow. Keeps the existing architecture-modes diagram and links it from the index.

Closes #363