### PR TITLE
Standardize CLAUDE.md workflow rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,18 @@
 
 Minimal Flutter app. UI built with [Forui](https://forui.dev) (`FTheme` + `F*` widgets).
 
+## Workflow rules (enforced)
+
+- Never work on `main`. Create an issue (labeled) → branch `feature/<issue#>_PascalCase`
+  or `fix/<issue#>_PascalCase` → PR (labeled) with `Closes #<issue>` → squash-merge +
+  delete branch.
+- Use **bun** as the package manager / task runner — never npm, npx, or node directly.
+- Use CLI tooling whenever one exists (`gh issue create`, `gh pr create`, generators, etc.).
+- No AI / Claude attribution in commits or PRs. Ever.
+- No test plans in PRs. PR body is **Summary** + `Closes #<issue>` only.
+- Commit subject: short imperative.
+- PR labels: `bug`, `enhancement`, `feature`, `refactor`, `CI/CD`, `dependencies`, `documentation`.
+
 ## App modes (account vs private)
 
 The app runs in one of two modes, chosen at the gate (`AppModeService`):
@@ -19,18 +31,6 @@ paths are **never hardcoded** in the client. The private connect flow is one gen
 screen that branches on the catalog `privateAuthStrategy` (`token` / `scrape`).
 
 See `docs/architecture-modes.md` for the full diagram.
-
-## Workflow rules (enforced)
-
-- Never work on `main`. Create an issue (labeled) → branch `feature/<issue#>_PascalCase`
-  or `fix/<issue#>_PascalCase` → PR (labeled) with `Closes #<issue>` → squash-merge +
-  delete branch.
-- Use CLI generators whenever one exists — `npx create-expo-app`, `npx expo install`,
-  `gh issue create`, `gh pr create`, etc.
-- No AI / Claude attribution in commits or PRs. Ever.
-- No test plans in PRs. PR body is **Summary** + `Closes #<issue>` only.
-- Commit subject: short imperative.
-- PR labels: `bug`, `enhancement`, `feature`, `refactor`, `CI/CD`, `dependencies`, `documentation`.
 
 ## Tasks (preferred)
 


### PR DESCRIPTION
Adds/standardizes the **Workflow rules (enforced)** section so every repo's CLAUDE.md shares the same workflow conventions (bun, branch→PR, no AI attribution, labels). Existing stack-specific notes are kept.