### PR TITLE
Surfaced API errors as app-wide toasts

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:forui/forui.dart';
 import 'l10n/app_localizations.dart';
 import 'services/app_mode_service.dart';
 import 'services/theme_service.dart';
+import 'services/toast_service.dart';
 import 'ui/core/ui/root_screen.dart';
 
 Future<void> main() async {
@@ -22,6 +23,7 @@ class SchulyApp extends StatelessWidget {
       animation: ThemeService.instance,
       builder: (context, _) {
         return MaterialApp(
+          navigatorKey: ToastService.navigatorKey,
           onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
           localizationsDelegates: const [
             ...AppLocalizations.localizationsDelegates,

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -3,6 +3,7 @@ import 'package:schuly_api/schuly_api.dart';
 
 import '../config/oidc_config.dart';
 import 'auth_service.dart';
+import 'toast_service.dart';
 
 /// Singleton-ish wrapper around the generated [SchulyApi]. Pre-wires the
 /// backend base URL and an interceptor that attaches the Pocket ID bearer on
@@ -39,15 +40,21 @@ class ApiClient {
                 options.extra['_retried'] = true;
                 options.headers['Authorization'] = 'Bearer $newToken';
                 try {
+                  // Silent on success — a refreshed-and-retried request is normal.
                   return handler.resolve(await _dio.fetch(options));
                 } on DioException catch (retryError) {
+                  _toastHttpError(retryError);
                   return handler.next(retryError);
                 }
               }
               // Refresh failed → the refresh token is dead too. Clear the
               // session so the auth gate bounces the user to sign-in.
+              ToastService.error('Session expired', 'Please sign in again.');
               await AuthService.signOut();
+              return handler.next(e);
             }
+            // Surface every other HTTP / network failure so it isn't silent.
+            _toastHttpError(e);
             handler.next(e);
           },
         ),
@@ -70,5 +77,17 @@ class ApiClient {
   Future<String?> _refresh() {
     return _refreshing ??=
         AuthService.refreshAccessToken().whenComplete(() => _refreshing = null);
+  }
+}
+
+/// Toasts an HTTP / network failure so API errors aren't silent — the status
+/// code (or "network") plus the method and path that failed.
+void _toastHttpError(DioException e) {
+  final code = e.response?.statusCode;
+  final r = e.requestOptions;
+  if (code != null) {
+    ToastService.error('Request failed ($code)', '${r.method} ${r.uri.path}');
+  } else {
+    ToastService.error('Network error', "Couldn't reach the server.");
   }
 }

--- a/lib/services/toast_service.dart
+++ b/lib/services/toast_service.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/widgets.dart';
+import 'package:forui/forui.dart';
+
+/// App-wide toasts. [navigatorKey] is attached to the root `MaterialApp`, and the
+/// root `FToaster` wraps the navigator — so its context can surface a toast from
+/// anywhere, including services that have no `BuildContext`. Use this for errors
+/// and notices the user would otherwise never see (silent fetch/sync failures).
+///
+/// Alignment is intentionally left to the root `FToaster` (top-anchored) so all
+/// toasts share one position.
+class ToastService {
+  ToastService._();
+
+  static final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+  static void error(String title, [Object? detail]) =>
+      _show(title, _clean(detail), FIcons.circleAlert);
+
+  static void success(String title, [String? description]) =>
+      _show(title, description, FIcons.circleCheck);
+
+  static void info(String title, [String? description]) =>
+      _show(title, description, FIcons.info);
+
+  static void _show(String title, String? description, IconData icon) {
+    final context = navigatorKey.currentContext;
+    if (context == null) return;
+    showFToast(
+      context: context,
+      icon: Icon(icon),
+      title: Text(title),
+      description: description == null || description.isEmpty ? null : Text(description),
+    );
+  }
+
+  /// Turn an exception into a short, single-line, user-facing detail.
+  static String? _clean(Object? detail) {
+    if (detail == null) return null;
+    var s = detail.toString().replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (s.startsWith('Exception: ')) s = s.substring(11);
+    return s.length > 140 ? '${s.substring(0, 139)}…' : s;
+  }
+}

--- a/lib/ui/account/account_page.dart
+++ b/lib/ui/account/account_page.dart
@@ -8,6 +8,7 @@ import '../../config/oidc_config.dart';
 import '../../services/active_account_service.dart';
 import '../../services/api_client.dart';
 import '../../services/school_data_service.dart';
+import '../../services/toast_service.dart';
 import '../classes/class_detail_screen.dart';
 import '../documents/documents_page.dart';
 
@@ -99,10 +100,13 @@ class _AccountPageState extends State<AccountPage> {
       await SchoolDataService.instance.refresh();
       await _loadSyncStatus();
       if (mounted) setState(() => _syncMsg = 'Synced just now');
+      ToastService.success('Synced', 'Fetched fresh data from the provider.');
     } on DioException catch (e) {
+      // The HTTP error itself is toasted centrally by the Dio interceptor.
       if (mounted) setState(() => _syncMsg = 'Sync failed (${e.response?.statusCode ?? 'network'})');
     } catch (e) {
       if (mounted) setState(() => _syncMsg = 'Sync failed');
+      ToastService.error('Sync failed', e);
     } finally {
       if (mounted) setState(() => _syncing = false);
     }


### PR DESCRIPTION
Add a context-free ToastService (root navigator key) and a Dio error interceptor so HTTP/network failures and a dead session surface a toast instead of failing silently. Sync success/failure on the account page toasts too.

Closes #367