### PR TITLE
Replaced em dashes with hyphens across the app

### DIFF
--- a/lib/config/oidc_config.dart
+++ b/lib/config/oidc_config.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 /// Resolved OIDC settings for the active backend. Everything except the backend
-/// base URL is discovered at runtime — the backend's `/api/app` provides the
+/// base URL is discovered at runtime - the backend's `/api/app` provides the
 /// authority, client id, scope and redirect uri, and the provider's OIDC
 /// discovery document provides the authorize/token endpoints. Nothing
 /// provider-specific (Keycloak vs Pocket ID vs …) is hardcoded.
@@ -30,7 +30,7 @@ class OidcSettings {
 }
 
 class OidcConfig {
-  // Backend base URL. Override per build — never hardcode a machine IP here:
+  // Backend base URL. Override per build - never hardcode a machine IP here:
   //   flutter build apk --dart-define=BACKEND_BASE_URL=http://<dev-box-lan-ip>:5033
   // Defaults to localhost: use `adb reverse tcp:5033 tcp:5033` over USB, or
   // `http://10.0.2.2:5033` on the emulator.
@@ -43,7 +43,7 @@ class OidcConfig {
   static Future<OidcSettings>? _loading;
 
   /// Loads (once) and caches the OIDC settings from the backend. Safe to call
-  /// from multiple places concurrently — the in-flight load is shared, and a
+  /// from multiple places concurrently - the in-flight load is shared, and a
   /// failed load is not cached so the next call retries.
   static Future<OidcSettings> settings() {
     final cached = _settings;

--- a/lib/domain/my_school.dart
+++ b/lib/domain/my_school.dart
@@ -4,8 +4,8 @@ import '../config/oidc_config.dart';
 
 /// A school the signed-in user belongs to, from `GET /api/schools/my-schools`.
 /// Carries the school name plus the user's identity (full name + email) at
-/// that school — what the account switcher displays. [provider] is the catalog
-/// system key, and [pluginBasePath] its plugin route — both discovered from the
+/// that school - what the account switcher displays. [provider] is the catalog
+/// system key, and [pluginBasePath] its plugin route - both discovered from the
 /// backend catalog, never hardcoded.
 class MySchool {
   final String id;

--- a/lib/services/active_account_service.dart
+++ b/lib/services/active_account_service.dart
@@ -80,7 +80,7 @@ class ActiveAccountService extends ChangeNotifier {
   /// Maps schoolId → (provider, plugin account id, plugin base path) by
   /// cross-referencing each catalog system's plugin accounts (which expose
   /// `schoolUserId` + `id`) against the user's SchoolUsers. The set of plugins
-  /// and their routes comes entirely from the backend catalog — no provider is
+  /// and their routes comes entirely from the backend catalog - no provider is
   /// hardcoded. Best-effort: returns an empty map on any failure.
   Future<Map<String, ({String provider, String accountId, String? pluginBasePath})>>
       _detectPluginAccounts() async {

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -40,7 +40,7 @@ class ApiClient {
                 options.extra['_retried'] = true;
                 options.headers['Authorization'] = 'Bearer $newToken';
                 try {
-                  // Silent on success — a refreshed-and-retried request is normal.
+                  // Silent on success - a refreshed-and-retried request is normal.
                   return handler.resolve(await _dio.fetch(options));
                 } on DioException catch (retryError) {
                   _toastHttpError(retryError);
@@ -67,7 +67,7 @@ class ApiClient {
   late final SchulyApi api;
 
   /// The configured Dio (auth + refresh interceptor, backend base URL) for
-  /// requests the typed client doesn't cover well — e.g. binary downloads.
+  /// requests the typed client doesn't cover well - e.g. binary downloads.
   Dio get dio => _dio;
 
   /// In-flight refresh, shared so concurrent 401s trigger a single token
@@ -80,7 +80,7 @@ class ApiClient {
   }
 }
 
-/// Toasts an HTTP / network failure so API errors aren't silent — the status
+/// Toasts an HTTP / network failure so API errors aren't silent - the status
 /// code (or "network") plus the method and path that failed.
 void _toastHttpError(DioException e) {
   final code = e.response?.statusCode;

--- a/lib/services/app_mode_service.dart
+++ b/lib/services/app_mode_service.dart
@@ -2,8 +2,8 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// How the app runs:
-/// - [account] — full mode: Pocket ID sign-in + the Schuly backend account.
-/// - [private] — no account; data is proxied statelessly and kept only on-device.
+/// - [account] - full mode: Pocket ID sign-in + the Schuly backend account.
+/// - [private] - no account; data is proxied statelessly and kept only on-device.
 enum AppMode { account, private }
 
 /// Holds the selected [AppMode], persisted locally. Mirrors [ThemeService]:

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -180,7 +180,7 @@ class AuthService {
 
   /// Exchanges the stored refresh token for a fresh access token and persists
   /// the result. Returns the new access token, or null if there's no refresh
-  /// token or the exchange failed — in which case the caller should treat the
+  /// token or the exchange failed - in which case the caller should treat the
   /// session as expired.
   static Future<String?> refreshAccessToken() async {
     final refreshToken = await getRefreshToken();
@@ -215,7 +215,7 @@ class AuthService {
 
   /// Decodes the persisted OIDC ID token's payload. Returns its claims
   /// (`name`, `email`, `picture`, …) or null if there's no token / it's
-  /// malformed. Pure local decode — no signature verification, which is fine
+  /// malformed. Pure local decode - no signature verification, which is fine
   /// since the token was already validated at exchange time.
   static Future<Map<String, dynamic>?> getIdTokenClaims() async {
     await _ensureMigrated();

--- a/lib/services/private_account_store.dart
+++ b/lib/services/private_account_store.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 /// On-device credentials for a private-mode (account-free) connection.
-/// Held only in the device keystore — never sent to or stored on a Schuly
+/// Held only in the device keystore - never sent to or stored on a Schuly
 /// account. Provider-agnostic: [loginMethod] (from the backend catalog) drives
 /// how the connection authenticates and where its data is fetched.
 class PrivateAccount {
@@ -33,7 +33,7 @@ class PrivateAccount {
   final String? password;
 
   /// TOTP seed (normalized base32). Lets Schuly regenerate the second factor
-  /// on-device — for silent re-login and the in-app authenticator. Stored only
+  /// on-device - for silent re-login and the in-app authenticator. Stored only
   /// in the device keystore, like every other field here.
   final String? totpSecret;
 

--- a/lib/services/private_data_adapter.dart
+++ b/lib/services/private_data_adapter.dart
@@ -75,7 +75,7 @@ class PrivateDataAdapter {
       e.map(agendaEntry).toList(growable: false);
 
   /// Derives the student's classes from the distinct subjects across their
-  /// grades and exams, attaching each subject's exams — mirroring how the
+  /// grades and exams, attaching each subject's exams - mirroring how the
   /// account-mode backend sync creates a Class per course. (The token-strategy
   /// endpoints have no standalone classes source, so this is the private-mode analogue.)
   static List<ClassDto> classes(

--- a/lib/services/school_data_service.dart
+++ b/lib/services/school_data_service.dart
@@ -168,7 +168,7 @@ class SchoolDataService extends ChangeNotifier {
     try {
       if (account.accessToken != null) {
         // Token-strategy systems: batched endpoints with a passwordless token
-        // refresh on expiry. A stored access token is the marker — token logins
+        // refresh on expiry. A stored access token is the marker - token logins
         // mint one; scrape (credential-replay) systems don't.
         final d = await TokenProxyClient.instance.fetchAll(account);
         if (d.refreshedAccount != null) {

--- a/lib/services/school_systems_service.dart
+++ b/lib/services/school_systems_service.dart
@@ -5,7 +5,7 @@ import '../domain/school_system.dart';
 
 /// Fetches the backend-served catalog of school systems (anonymous endpoint).
 /// The backend is the **sole** source of truth for which systems exist and how
-/// to log in — the app hardcodes nothing and renders the picker + login forms
+/// to log in - the app hardcodes nothing and renders the picker + login forms
 /// entirely from this list.
 ///
 /// Uses a clean [Dio] with no OIDC interceptor: private (secure) mode relies on

--- a/lib/services/toast_service.dart
+++ b/lib/services/toast_service.dart
@@ -2,7 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:forui/forui.dart';
 
 /// App-wide toasts. [navigatorKey] is attached to the root `MaterialApp`, and the
-/// root `FToaster` wraps the navigator — so its context can surface a toast from
+/// root `FToaster` wraps the navigator - so its context can surface a toast from
 /// anywhere, including services that have no `BuildContext`. Use this for errors
 /// and notices the user would otherwise never see (silent fetch/sync failures).
 ///

--- a/lib/services/token_proxy_client.dart
+++ b/lib/services/token_proxy_client.dart
@@ -144,11 +144,11 @@ class TokenProxyClient {
   /// Re-establishes a token, returning an account carrying the new token and
   /// rotated context_state, or null if it isn't possible / failed. Tries the
   /// cheap passwordless refresh first; if that's unavailable or rejected, falls
-  /// back to a full credential re-login from the vaulted email/password/seed —
+  /// back to a full credential re-login from the vaulted email/password/seed -
   /// Schuly regenerates the OTP itself, so the user is never prompted.
   Future<PrivateAccount?> _refreshAccount(PrivateAccount a) async {
-    // Credential logins (ms-entrance) have no captured user-agent — it manages
-    // its own — so only context_state is required to replay.
+    // Credential logins (ms-entrance) have no captured user-agent - it manages
+    // its own - so only context_state is required to replay.
     if (a.contextState != null) {
       final r = await refresh(
         basePath: a.statelessBasePath,

--- a/lib/services/totp_service.dart
+++ b/lib/services/totp_service.dart
@@ -3,7 +3,7 @@ import 'package:otp/otp.dart';
 /// A parsed TOTP descriptor. Built from either a bare base32 secret or a full
 /// `otpauth://totp/...` URI (as encoded in an authenticator QR code).
 class TotpConfig {
-  /// Normalized base32 secret — no spaces/dashes, upper-case.
+  /// Normalized base32 secret - no spaces/dashes, upper-case.
   final String secret;
   final int digits;
   final int period; // seconds
@@ -56,7 +56,7 @@ class TotpConfig {
     return secret.isEmpty ? null : TotpConfig(secret: secret);
   }
 
-  /// Strips spaces/dashes and upper-cases — accepts the way authenticators
+  /// Strips spaces/dashes and upper-cases - accepts the way authenticators
   /// display seeds (grouped, lower-case) as well as the raw form.
   static String normalizeSecret(String s) =>
       s.replaceAll(RegExp(r'[\s-]'), '').toUpperCase();

--- a/lib/ui/absences/absences_page.dart
+++ b/lib/ui/absences/absences_page.dart
@@ -6,7 +6,7 @@ import 'package:schuly_api/schuly_api.dart';
 import '../../services/api_client.dart';
 import '../../services/school_data_service.dart';
 
-/// Absences tab — lists the user's absences/delays and lets them report,
+/// Absences tab - lists the user's absences/delays and lets them report,
 /// edit, and delete (the one writable area).
 class AbsencesPage extends StatelessWidget {
   const AbsencesPage({super.key});
@@ -204,8 +204,8 @@ class _AbsenceFormState extends State<_AbsenceForm> {
     final colors = context.theme.colors;
     String d(DateTime x) => '${x.day}.${x.month}.${x.year}';
     // showFSheet strips MediaQuery.padding (so SafeArea is a no-op); viewPadding
-    // survives. Clear whichever is taller — the keyboard (viewInsets) or the
-    // Android gesture/nav bar (viewPadding) — so the Save button is never hidden.
+    // survives. Clear whichever is taller - the keyboard (viewInsets) or the
+    // Android gesture/nav bar (viewPadding) - so the Save button is never hidden.
     final keyboard = MediaQuery.viewInsetsOf(context).bottom;
     final navBar = MediaQuery.viewPaddingOf(context).bottom;
     return Container(

--- a/lib/ui/account/account_page.dart
+++ b/lib/ui/account/account_page.dart
@@ -12,7 +12,7 @@ import '../../services/toast_service.dart';
 import '../classes/class_detail_screen.dart';
 import '../documents/documents_page.dart';
 
-/// Account tab — profile details, enrolled classes, app info, and the account
+/// Account tab - profile details, enrolled classes, app info, and the account
 /// switcher + sign out.
 class AccountPage extends StatefulWidget {
   final String? pictureUrl;
@@ -67,7 +67,7 @@ class _AccountPageState extends State<AccountPage> {
   }
 
   /// The version shown is the active provider's plugin version, read off its
-  /// `…/status` endpoint — not the backend app version.
+  /// `…/status` endpoint - not the backend app version.
   Future<void> _loadVersion() async {
     try {
       final active = ActiveAccountService.instance.active;
@@ -119,9 +119,9 @@ class _AccountPageState extends State<AccountPage> {
     final me = SchoolDataService.instance.me;
     final classes = me?.classes ?? const <UserClassDto>[];
 
-    String fmtDate(Date? d) => d == null ? '—' : '${d.day}.${d.month}.${d.year}';
+    String fmtDate(Date? d) => d == null ? '-' : '${d.day}.${d.month}.${d.year}';
     final fullName = me == null
-        ? (widget.userName ?? '—')
+        ? (widget.userName ?? '-')
         : '${me.firstName} ${me.lastName}'.trim();
     final initial = fullName.isNotEmpty ? fullName.characters.first.toUpperCase() : '?';
     final fallback = Text(initial,
@@ -259,7 +259,7 @@ class _AccountPageState extends State<AccountPage> {
           child: FTile(
             prefix: const Icon(FIcons.info),
             title: const Text('Version'),
-            suffix: Text(_version ?? '—', style: TextStyle(color: colors.mutedForeground)),
+            suffix: Text(_version ?? '-', style: TextStyle(color: colors.mutedForeground)),
           ),
         ),
         const SizedBox(height: 4),
@@ -314,7 +314,7 @@ class _InfoTile extends StatelessWidget {
         child: FTile(
           prefix: Icon(icon),
           title: Text(label),
-          details: Text((value?.isNotEmpty ?? false) ? value! : '—'),
+          details: Text((value?.isNotEmpty ?? false) ? value! : '-'),
         ),
       );
 }

--- a/lib/ui/account/unified_connect_screen.dart
+++ b/lib/ui/account/unified_connect_screen.dart
@@ -10,7 +10,7 @@ import '../widgets/dynamic_login_form.dart';
 /// (`POST /api/auth/login`). Renders the chosen system's catalog `loginFields`
 /// and forwards them as `{ systemKey, fields, displayName }`; the dumb CRM routes
 /// to the owning plugin (`IPluginLogin`) which authenticates the provider. No
-/// provider logic and no WebView here — works for any `credentials` system.
+/// provider logic and no WebView here - works for any `credentials` system.
 /// Pops the new account id (`String`) on success.
 class UnifiedConnectScreen extends StatefulWidget {
   final SchoolSystem system;

--- a/lib/ui/classes/class_detail_screen.dart
+++ b/lib/ui/classes/class_detail_screen.dart
@@ -6,7 +6,7 @@ import '../../config/oidc_config.dart';
 import '../../services/api_client.dart';
 import '../core/grade_color.dart';
 
-/// Detail for a single class: students, exams, and agenda — fetched on demand
+/// Detail for a single class: students, exams, and agenda - fetched on demand
 /// via GET /Class/search.
 class ClassDetailScreen extends StatefulWidget {
   final String classId;

--- a/lib/ui/core/grade_color.dart
+++ b/lib/ui/core/grade_color.dart
@@ -11,7 +11,7 @@ Color gradeColor(BuildContext context, num grade) {
 }
 
 /// A score is only a real grade when it's on the 1–6 scale. 0/null means the
-/// exam exists but isn't graded yet — excluded from averages and shown as "—".
+/// exam exists but isn't graded yet - excluded from averages and shown as "-".
 bool isGraded(num? score) => score != null && score > 0;
 
 String formatGrade(num grade) {
@@ -21,7 +21,7 @@ String formatGrade(num grade) {
       : (s.endsWith('0') ? grade.toStringAsFixed(1) : s);
 }
 
-/// Coloured grade chip. Ungraded (≤0) scores render as a muted "—".
+/// Coloured grade chip. Ungraded (≤0) scores render as a muted "-".
 class GradePill extends StatelessWidget {
   final num? score;
   const GradePill(this.score, {super.key});
@@ -36,7 +36,7 @@ class GradePill extends StatelessWidget {
           color: colors.muted,
           borderRadius: BorderRadius.circular(8),
         ),
-        child: Text('—', style: TextStyle(color: colors.mutedForeground, fontWeight: FontWeight.w700)),
+        child: Text('-', style: TextStyle(color: colors.mutedForeground, fontWeight: FontWeight.w700)),
       );
     }
     final c = gradeColor(context, score!);

--- a/lib/ui/core/ui/root_screen.dart
+++ b/lib/ui/core/ui/root_screen.dart
@@ -138,7 +138,7 @@ class _RootScreenState extends State<RootScreen> {
           children: [
             if (isPrivate) ...[
               const Text(
-                'Private mode — no account, nothing stored on a server.',
+                'Private mode - no account, nothing stored on a server.',
                 textAlign: TextAlign.center,
               ),
               FButton(

--- a/lib/ui/dashboard/dashboard_screen.dart
+++ b/lib/ui/dashboard/dashboard_screen.dart
@@ -58,7 +58,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
   }
 
   Future<void> _bootstrap() async {
-    // Private mode: no Pocket ID / school switcher — just load proxied data.
+    // Private mode: no Pocket ID / school switcher - just load proxied data.
     if (AppModeService.instance.isPrivate) {
       final account = await PrivateAccountStore.instance.load();
       if (mounted) {

--- a/lib/ui/dashboard/widgets/accounts_sidebar.dart
+++ b/lib/ui/dashboard/widgets/accounts_sidebar.dart
@@ -18,7 +18,7 @@ import 'add_school_modal.dart';
 /// connect screen on the *parent* navigator (so it survives sheet dismissal),
 /// and on success refreshes the accounts list and selects the new account.
 class AccountsSidebar extends StatelessWidget {
-  /// Parent navigator — needed for pushing the connect screen, since this
+  /// Parent navigator - needed for pushing the connect screen, since this
   /// widget is mounted inside a modal sheet route.
   final NavigatorState parentNavigator;
   final VoidCallback? onSignOut;
@@ -93,7 +93,7 @@ class AccountsSidebar extends StatelessWidget {
           final isPrivate = AppModeService.instance.isPrivate;
 
           // showFSheet strips MediaQuery.padding, so SafeArea is a no-op here.
-          // viewPadding survives, so pad the content with it manually — keeps
+          // viewPadding survives, so pad the content with it manually - keeps
           // the background full-bleed while clearing the status bar / nav bar.
           final viewPadding = MediaQuery.viewPaddingOf(context);
           return Padding(
@@ -128,7 +128,7 @@ class AccountsSidebar extends StatelessWidget {
                           child: Padding(
                             padding: const EdgeInsets.all(24),
                             child: Text(
-                              'Private mode — your data stays on this device.',
+                              'Private mode - your data stays on this device.',
                               textAlign: TextAlign.center,
                               style: typography.sm
                                   .copyWith(color: colors.mutedForeground),
@@ -234,7 +234,7 @@ class AccountsSidebar extends StatelessWidget {
 
 /// Rounded-square avatar for a school account, à la Teams' org tiles. Shows the
 /// school's backend-supplied logo on a muted surface, falling back to a generic
-/// icon — no per-provider asset is bundled in the app.
+/// icon - no per-provider asset is bundled in the app.
 class _SchoolAvatar extends StatelessWidget {
   static const double size = 40;
   final String? logoUrl;

--- a/lib/ui/dashboard/widgets/add_school_modal.dart
+++ b/lib/ui/dashboard/widgets/add_school_modal.dart
@@ -9,7 +9,7 @@ import '../../account/unified_connect_screen.dart';
 /// Full add-school flow: fetch the backend's school-system catalog, show the
 /// picker, then run the chosen system's connect screen. Returns the new account
 /// id, or null if the user cancelled at any step. [navigator] is the navigator
-/// the connect screen is pushed onto — pass the dashboard's, not a sheet/dialog
+/// the connect screen is pushed onto - pass the dashboard's, not a sheet/dialog
 /// navigator that may be torn down mid-flow.
 Future<String?> runAddSchoolFlow(
   BuildContext context,
@@ -31,7 +31,7 @@ Future<String?> runAddSchoolFlow(
 
 /// Fetches the catalog, showing an error dialog and returning null on failure
 /// (or when the backend advertises no systems). The app keeps no offline
-/// fallback — the backend is the sole source of truth.
+/// fallback - the backend is the sole source of truth.
 Future<List<SchoolSystem>?> fetchSystemsOrShowError(BuildContext context) async {
   List<SchoolSystem> systems;
   try {

--- a/lib/ui/documents/documents_page.dart
+++ b/lib/ui/documents/documents_page.dart
@@ -11,7 +11,7 @@ import '../../services/active_account_service.dart';
 import '../../services/api_client.dart';
 import '../../services/school_data_service.dart';
 
-/// Documents screen — mirrors a typical school "personal dossier": files are
+/// Documents screen - mirrors a typical school "personal dossier": files are
 /// grouped into folders by their category (report cards / Zeugnisse get their
 /// own folder, pinned first). Pull down to fetch fresh files from the provider;
 /// tapping a file downloads and opens it.
@@ -122,7 +122,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
               Padding(
                 padding: const EdgeInsets.only(top: 48),
                 child: Center(
-                  child: Text('No documents yet — pull down to refresh.',
+                  child: Text('No documents yet - pull down to refresh.',
                       textAlign: TextAlign.center,
                       style: TextStyle(color: colors.mutedForeground)),
                 ),

--- a/lib/ui/grades/grades_page.dart
+++ b/lib/ui/grades/grades_page.dart
@@ -91,7 +91,7 @@ class _GradesViewState extends State<_GradesView> {
     final byClass = <String, List<ExamDto>>{};
     for (final e in graded) {
       if (!inSelection(_semesterKey(e.date))) continue;
-      byClass.putIfAbsent(e.classId ?? '—', () => []).add(e);
+      byClass.putIfAbsent(e.classId ?? '-', () => []).add(e);
     }
     for (final list in byClass.values) {
       list.sort((a, b) => (a.date?.compareTo(b.date ?? a.date!) ?? 0));
@@ -226,7 +226,7 @@ class _ExamDetailSheet extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(label, style: typography.sm.copyWith(color: colors.mutedForeground)),
-              Text(isGraded(value) ? formatGrade(v) : '—',
+              Text(isGraded(value) ? formatGrade(v) : '-',
                   style: typography.sm.copyWith(fontWeight: FontWeight.w700, color: c)),
             ],
           ),

--- a/lib/ui/home/home_page.dart
+++ b/lib/ui/home/home_page.dart
@@ -27,7 +27,7 @@ class HomePage extends StatelessWidget {
     final upcoming = svc.agenda.where((a) => !isHoliday(a) && dayOf(a.date).isAfter(today)).toList()
       ..sort((a, b) => a.date.compareTo(b.date));
 
-    // Current or upcoming holidays (those whose end—or start—hasn't passed).
+    // Current or upcoming holidays (those whose end-or start-hasn't passed).
     final holidays = svc.agenda
         .where((a) => isHoliday(a) && !dayOf(a.endDate ?? a.date).isBefore(today))
         .toList()
@@ -43,7 +43,7 @@ class HomePage extends StatelessWidget {
       ...svc.classNameById,
     };
     // Only real grades on the latest-grades card (drop ungraded 0 placeholders),
-    // newest first by the exam date — across semesters a graded exam can be from
+    // newest first by the exam date - across semesters a graded exam can be from
     // an earlier school year, so date order (not list order) is what's "latest".
     final recentGrades = myGrades.entries
         .where((e) => isGraded(e.value.score))
@@ -168,7 +168,7 @@ class HomePage extends StatelessWidget {
   }
 }
 
-/// A plain section: a header label followed by spaced tiles — matching the
+/// A plain section: a header label followed by spaced tiles - matching the
 /// Grades page (no enclosing card; the tiles carry their own borders).
 class _Section extends StatelessWidget {
   final String title;

--- a/lib/ui/onboarding/onboarding_screen.dart
+++ b/lib/ui/onboarding/onboarding_screen.dart
@@ -5,7 +5,7 @@ import 'package:forui/forui.dart';
 /// followed by the Account-vs-Private mode choice. Forui has no carousel
 /// widget, so the swipe is a plain [PageView]; everything else is Forui.
 ///
-/// The two mode buttons on the last page are the only exits — both should mark
+/// The two mode buttons on the last page are the only exits - both should mark
 /// onboarding as seen and start the matching gate flow (sign-in / connect).
 class OnboardingScreen extends StatefulWidget {
   final Future<void> Function() onChooseAccount;

--- a/lib/ui/private/authenticator_screen.dart
+++ b/lib/ui/private/authenticator_screen.dart
@@ -9,7 +9,7 @@ import '../../services/totp_service.dart';
 
 /// In-app authenticator for the connected private-mode school. Schuly acts as
 /// the TOTP client: it generates the current code from the vaulted seed and
-/// refreshes it every second, with a countdown and tap-to-copy — so the code is
+/// refreshes it every second, with a countdown and tap-to-copy - so the code is
 /// available for use elsewhere, not just for Schuly's own re-login.
 class AuthenticatorScreen extends StatefulWidget {
   const AuthenticatorScreen({super.key});

--- a/lib/ui/private/private_connect_screen.dart
+++ b/lib/ui/private/private_connect_screen.dart
@@ -11,7 +11,7 @@ import '../widgets/dynamic_login_form.dart';
 import 'totp_scan_screen.dart';
 
 /// Generic private-mode connect screen. Renders the chosen [system]'s
-/// backend-described `loginFields` and connects headlessly — no WebView. The
+/// backend-described `loginFields` and connects headlessly - no WebView. The
 /// integration shape comes from the catalog `privateAuthStrategy`: `token`
 /// systems log in via the stateless credential `/login` (mints a token +
 /// context_state); `scrape` systems replay username/password per fetch.
@@ -162,7 +162,7 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
         spacing: 16,
         children: [
           const Text(
-            'Private mode keeps everything on this device — no account, '
+            'Private mode keeps everything on this device - no account, '
             'nothing stored on a server.',
           ),
           DynamicLoginForm(controller: _form, onScanField: _scanTotp),

--- a/lib/ui/private/totp_scan_screen.dart
+++ b/lib/ui/private/totp_scan_screen.dart
@@ -6,7 +6,7 @@ import '../../services/totp_service.dart';
 
 /// Scans an authenticator QR code and returns the raw payload (an
 /// `otpauth://` URI, or a bare secret) to the caller. Only codes that parse as
-/// a usable TOTP are accepted — other QR codes are ignored so the camera keeps
+/// a usable TOTP are accepted - other QR codes are ignored so the camera keeps
 /// scanning. Pops with the scanned string, or null if cancelled.
 ///
 /// The [MobileScanner] manages its own camera controller lifecycle.

--- a/lib/ui/timetable/timetable_page.dart
+++ b/lib/ui/timetable/timetable_page.dart
@@ -31,7 +31,7 @@ class _TimetablePageState extends State<TimetablePage> {
   }
 
   /// Once agenda data is available (it loads after this page mounts), anchor
-  /// the calendar on the nearest day with entries — unless the user already
+  /// the calendar on the nearest day with entries - unless the user already
   /// picked a day.
   void _autoAnchor() {
     if (_userPicked || _selected != null) return;

--- a/lib/ui/widgets/dynamic_login_form.dart
+++ b/lib/ui/widgets/dynamic_login_form.dart
@@ -58,7 +58,7 @@ class DynamicLoginForm extends StatelessWidget {
     super.key,
   });
 
-  /// A field that carries a TOTP seed — obscured and offered a QR scanner.
+  /// A field that carries a TOTP seed - obscured and offered a QR scanner.
   /// Detected by an explicit `totp` type or the conventional `totp` key, so the
   /// backend catalog can opt in without the app hardcoding a provider.
   static bool _isTotp(SchoolSystemLoginField f) =>


### PR DESCRIPTION
Replaced all em dashes (—) with hyphens (-) in the app's own source - user-facing strings, empty-value placeholders, and comments. Excludes the generated lib/api/ client.

Closes #378