### PR TITLE
Added a hosted vs self-hosted server step to onboarding

### DIFF
--- a/lib/config/backend_config.dart
+++ b/lib/config/backend_config.dart
@@ -1,0 +1,50 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The backend the app talks to. Defaults to the hosted Schuly Cloud (baked in
+/// at build time via `--dart-define=BACKEND_BASE_URL`); a self-hoster can point
+/// it at their own instance during onboarding.
+///
+/// Persisted locally and loaded at startup *before* any HTTP client reads
+/// [url], so clients pick it up on first use - no live re-pointing needed. The
+/// onboarding server step likewise sets the URL before the first backend call.
+class BackendConfig {
+  BackendConfig._();
+
+  static const _key = 'backend.url';
+
+  /// The hosted default (Schuly Cloud). Override per build:
+  ///   flutter build apk --dart-define=BACKEND_BASE_URL=https://api.schuly.dev
+  static const hostedUrl = String.fromEnvironment(
+    'BACKEND_BASE_URL',
+    defaultValue: 'http://localhost:5033',
+  );
+
+  static String _url = hostedUrl;
+
+  /// Current backend base URL (no trailing slash).
+  static String get url => _url;
+
+  /// Whether the app is pointed at a custom (self-hosted) backend.
+  static bool get isCustom => _url != hostedUrl;
+
+  static Future<void> load() async {
+    final saved = (await SharedPreferences.getInstance()).getString(_key);
+    if (saved != null && saved.isNotEmpty) _url = saved;
+  }
+
+  /// Normalises and persists [value] (trailing slash trimmed). A null/empty
+  /// value, or one equal to the hosted default, resets to hosted. Returns the
+  /// resolved URL.
+  static Future<String> setUrl(String? value) async {
+    final prefs = await SharedPreferences.getInstance();
+    final v = value?.trim().replaceAll(RegExp(r'/+$'), '');
+    if (v == null || v.isEmpty || v == hostedUrl) {
+      _url = hostedUrl;
+      await prefs.remove(_key);
+    } else {
+      _url = v;
+      await prefs.setString(_key, v);
+    }
+    return _url;
+  }
+}

--- a/lib/config/oidc_config.dart
+++ b/lib/config/oidc_config.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+import 'backend_config.dart';
+
 /// Resolved OIDC settings for the active backend. Everything except the backend
 /// base URL is discovered at runtime - the backend's `/api/app` provides the
 /// authority, client id, scope and redirect uri, and the provider's OIDC
@@ -30,14 +32,10 @@ class OidcSettings {
 }
 
 class OidcConfig {
-  // Backend base URL. Override per build - never hardcode a machine IP here:
-  //   flutter build apk --dart-define=BACKEND_BASE_URL=http://<dev-box-lan-ip>:5033
-  // Defaults to localhost: use `adb reverse tcp:5033 tcp:5033` over USB, or
-  // `http://10.0.2.2:5033` on the emulator.
-  static const backendBaseUrl = String.fromEnvironment(
-    'BACKEND_BASE_URL',
-    defaultValue: 'http://localhost:5033',
-  );
+  // Backend base URL, resolved at runtime from [BackendConfig] (hosted default
+  // or a self-hosted override chosen in onboarding). The build-time default
+  // lives in [BackendConfig.hostedUrl].
+  static String get backendBaseUrl => BackendConfig.url;
 
   static OidcSettings? _settings;
   static Future<OidcSettings>? _loading;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
+import 'config/backend_config.dart';
 import 'l10n/app_localizations.dart';
 import 'services/app_mode_service.dart';
 import 'services/theme_service.dart';
@@ -9,6 +10,7 @@ import 'ui/core/ui/root_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await BackendConfig.load();
   await AppModeService.instance.load();
   await ThemeService.instance.load();
   runApp(const SchulyApp());

--- a/lib/ui/onboarding/onboarding_screen.dart
+++ b/lib/ui/onboarding/onboarding_screen.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
-/// First-run onboarding: three intro pages explaining what Schuly shows,
-/// followed by the Account-vs-Private mode choice. Forui has no carousel
-/// widget, so the swipe is a plain [PageView]; everything else is Forui.
+import '../../config/backend_config.dart';
+
+/// First-run onboarding: three intro pages explaining what Schuly shows, then a
+/// server step (hosted vs self-hosted), then the Account-vs-Private mode choice.
+/// Forui has no carousel widget, so the swipe is a plain [PageView]; everything
+/// else is Forui.
 ///
 /// The two mode buttons on the last page are the only exits - both should mark
 /// onboarding as seen and start the matching gate flow (sign-in / connect).
@@ -22,8 +25,10 @@ class OnboardingScreen extends StatefulWidget {
 }
 
 class _OnboardingScreenState extends State<OnboardingScreen> {
-  static const _pageCount = 4;
-  static const _lastPage = _pageCount - 1;
+  static const _pageCount = 5;
+  // Pages 0-2 are intro slides (with a Next button); pages 3 (server) and 4
+  // (mode) carry their own Continue button.
+  static const _introPages = 3;
 
   final _controller = PageController();
   int _page = 0;
@@ -84,6 +89,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                         'averages, and browse your timetable, agenda, and '
                         'absences.',
                   ),
+                  _ServerPage(busy: _busy, onContinue: _next),
                   _ModeChoicePage(
                     busy: _busy,
                     onAccount: () => _choose(widget.onChooseAccount),
@@ -109,10 +115,11 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                   ),
               ],
             ),
-            // The last page carries its own CTAs; earlier pages get "Next".
+            // Intro pages get a "Next"; the server and mode pages carry their
+            // own Continue button.
             Padding(
               padding: const EdgeInsets.fromLTRB(24, 16, 24, 16),
-              child: _page < _lastPage
+              child: _page < _introPages
                   ? SizedBox(
                       width: double.infinity,
                       child: FButton(onPress: _next, child: const Text('Next')),
@@ -193,6 +200,135 @@ class _IntroPage extends StatelessWidget {
             style: typography.base.copyWith(color: colors.mutedForeground),
           ),
         ],
+      ),
+    );
+  }
+}
+
+enum _Server { hosted, custom }
+
+/// The server step: the hosted Schuly Cloud (default) or a self-hosted backend
+/// URL. Persists the choice to [BackendConfig] before continuing, so both
+/// account and private mode talk to the chosen backend.
+class _ServerPage extends StatefulWidget {
+  final bool busy;
+  final VoidCallback onContinue;
+
+  const _ServerPage({required this.busy, required this.onContinue});
+
+  @override
+  State<_ServerPage> createState() => _ServerPageState();
+}
+
+class _ServerPageState extends State<_ServerPage> {
+  _Server _selected = _Server.hosted;
+  final _urlCtrl = TextEditingController();
+  String? _error;
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _urlCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _continue() async {
+    if (widget.busy || _saving) return;
+    if (_selected == _Server.hosted) {
+      await BackendConfig.setUrl(null);
+      widget.onContinue();
+      return;
+    }
+    final raw = _urlCtrl.text.trim();
+    final uri = Uri.tryParse(raw);
+    final valid = raw.isNotEmpty &&
+        uri != null &&
+        (uri.isScheme('http') || uri.isScheme('https')) &&
+        uri.host.isNotEmpty;
+    if (!valid) {
+      setState(() => _error =
+          'Enter a valid http(s) URL, e.g. https://schuly.example.com');
+      return;
+    }
+    setState(() {
+      _saving = true;
+      _error = null;
+    });
+    await BackendConfig.setUrl(raw);
+    if (!mounted) return;
+    setState(() => _saving = false);
+    widget.onContinue();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+
+    return LayoutBuilder(
+      builder: (context, constraints) => SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(minHeight: constraints.maxHeight - 32),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Which server?',
+                textAlign: TextAlign.center,
+                style: typography.xl2.copyWith(fontWeight: FontWeight.w700),
+              ),
+              const SizedBox(height: 28),
+              _ModeCard(
+                icon: FIcons.cloud,
+                title: 'Schuly Cloud',
+                tag: 'Recommended',
+                body: 'The official Schuly server - the right choice for '
+                    'most people.',
+                selected: _selected == _Server.hosted,
+                onTap: widget.busy
+                    ? null
+                    : () => setState(() {
+                          _selected = _Server.hosted;
+                          _error = null;
+                        }),
+              ),
+              const SizedBox(height: 14),
+              _ModeCard(
+                icon: FIcons.server,
+                title: 'Self-hosted',
+                body: 'Connect to your own Schuly backend instance.',
+                selected: _selected == _Server.custom,
+                onTap: widget.busy
+                    ? null
+                    : () => setState(() => _selected = _Server.custom),
+              ),
+              if (_selected == _Server.custom) ...[
+                const SizedBox(height: 14),
+                FTextField(
+                  control: FTextFieldControl.managed(controller: _urlCtrl),
+                  label: const Text('Backend URL'),
+                  hint: 'https://schuly.example.com',
+                  autocorrect: false,
+                ),
+              ],
+              if (_error != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  _error!,
+                  textAlign: TextAlign.center,
+                  style: typography.sm.copyWith(color: colors.error),
+                ),
+              ],
+              const SizedBox(height: 24),
+              FButton(
+                onPress: (widget.busy || _saving) ? null : _continue,
+                child: Text(_saving ? 'Saving...' : 'Continue'),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
Added a runtime BackendConfig (hosted Schuly Cloud default + a persisted self-hosted override) and a 'Which server?' onboarding step before the mode choice. OidcConfig.backendBaseUrl now delegates to BackendConfig.url, so the HTTP clients pick up the chosen backend with no changes. The server step sets the URL before any backend call, so account and private mode both use it.

Closes #386