### PR TITLE
Started onboarding account creation on the register screen

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -72,7 +72,11 @@ class AuthService {
   /// 3. Open the URL in Chrome (external, supports passkeys).
   /// 4. Await the first incoming [OidcConfig.redirectUri] deep link.
   /// 5. Exchange the auth code for tokens.
-  static Future<AuthTokens> signIn() async {
+  /// Runs the OIDC PKCE flow. When [register] is true the authorize request
+  /// carries `prompt=create` (the OIDC registration hint), so providers that
+  /// support it - e.g. Keycloak - open the registration screen first; others
+  /// ignore it and fall back to login.
+  static Future<AuthTokens> signIn({bool register = false}) async {
     final cfg = await OidcConfig.settings();
     final (verifier, challenge) = _generatePkce();
     final state = DateTime.now().microsecondsSinceEpoch.toString();
@@ -85,6 +89,7 @@ class AuthService {
         'state': state,
         'code_challenge': challenge,
         'code_challenge_method': 'S256',
+        if (register) 'prompt': 'create',
       },
     );
 

--- a/lib/ui/core/ui/root_screen.dart
+++ b/lib/ui/core/ui/root_screen.dart
@@ -59,13 +59,13 @@ class _RootScreenState extends State<RootScreen> {
     if (mounted) setState(() => _ready = token != null);
   }
 
-  Future<void> _signIn() async {
+  Future<void> _signIn({bool register = false}) async {
     setState(() {
       _busy = true;
       _error = null;
     });
     try {
-      await AuthService.signIn();
+      await AuthService.signIn(register: register);
       await _refresh();
     } catch (e) {
       setState(() => _error = '$e');
@@ -86,7 +86,8 @@ class _RootScreenState extends State<RootScreen> {
     await OnboardingService.markSeen();
     if (mounted) setState(() => _onboarded = true);
     await AppModeService.instance.setMode(AppMode.account);
-    await _signIn();
+    // New users coming through onboarding start on the registration screen.
+    await _signIn(register: true);
   }
 
   Future<void> _onboardWithPrivate() async {


### PR DESCRIPTION
When a new user picks a Schuly account in onboarding, the OIDC flow now starts on the registration screen via prompt=create (Keycloak honors it; other providers fall back to login). The gate's re-login for returning users still opens the login screen.

Closes #395