### PR TITLE
Updated account-mode docs to reference Keycloak instead of Pocket ID

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,7 +18,7 @@ Minimal Flutter app. UI built with [Forui](https://forui.dev) (`FTheme` + `F*` w
 
 The app runs in one of two modes, chosen at the gate (`AppModeService`):
 
-- **Account mode** - OIDC login (Pocket ID) via `ApiClient`; data lives server-side
+- **Account mode** - OIDC login (Keycloak) via `ApiClient`; data lives server-side
   and the backend syncs it. The normal flow.
 - **Private / secure mode** - **no Schuly login, no OIDC**. Credentials live only in
   the device keystore (`PrivateAccountStore`); data is fetched live from the backend's

--- a/docs/architecture-modes.md
+++ b/docs/architecture-modes.md
@@ -15,7 +15,7 @@ flowchart TB
 
   subgraph ACCOUNT["🔐 Account mode - Schuly login"]
     direction TB
-    Login["OIDC login<br/>(Pocket ID)"]
+    Login["OIDC login<br/>(Keycloak)"]
     ApiClient["ApiClient<br/>Bearer token + auto-refresh"]
     Backend[("SchulyBackend<br/>authenticated /api/*")]
     DB[("PostgreSQL<br/>data stored per user")]
@@ -61,7 +61,7 @@ flowchart TB
 
 |                     | 🔐 Account mode                | 🕶️ Private / secure mode                          |
 | ------------------- | ------------------------------ | ------------------------------------------------- |
-| Auth to Schuly      | OIDC (Pocket ID) bearer        | **none**                                          |
+| Auth to Schuly      | OIDC (Keycloak) bearer        | **none**                                          |
 | HTTP client         | `ApiClient` (auth interceptor) | clean `Dio`, anonymous endpoints only             |
 | Where data lives    | server-side in Postgres        | **on-device only**                                |
 | Backend role        | stores + background-syncs      | live stateless proxy, stores nothing              |


### PR DESCRIPTION
Account mode's OIDC provider is the Schuly Keycloak (default; the app is provider-agnostic). Replaced the stale Pocket ID references.

Closes #399