### PR TITLE
Scaled long school-system names to fit one line

### DIFF
--- a/lib/ui/dashboard/widgets/add_school_modal.dart
+++ b/lib/ui/dashboard/widgets/add_school_modal.dart
@@ -140,14 +140,15 @@ class _SystemCard extends StatelessWidget {
                 children: [
                   logo,
                   const SizedBox(height: 8),
-                  Text(
-                    system.displayName,
-                    textAlign: TextAlign.center,
-                    maxLines: 1,
-                    softWrap: false,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                        fontWeight: FontWeight.w600, fontSize: 12),
+                  FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      system.displayName,
+                      maxLines: 1,
+                      softWrap: false,
+                      style: const TextStyle(
+                          fontWeight: FontWeight.w600, fontSize: 13),
+                    ),
                   ),
                   if (disabled)
                     Text(


### PR DESCRIPTION
Long names like 'Schulnetz' were truncated; a FittedBox now scales the name down to fit one line in full.

Closes #405