### PR TITLE
Added a Server setting to change the backend at runtime

### DIFF
--- a/lib/config/oidc_config.dart
+++ b/lib/config/oidc_config.dart
@@ -56,6 +56,13 @@ class OidcConfig {
     });
   }
 
+  /// Clears the cached settings so the next [settings] call re-fetches them -
+  /// used after the backend URL changes at runtime (the OIDC authority differs).
+  static void reset() {
+    _settings = null;
+    _loading = null;
+  }
+
   static Future<OidcSettings> _load() async {
     final app = await _getJson('$backendBaseUrl/api/app');
     final authority =

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:schuly_api/schuly_api.dart';
 
+import '../config/backend_config.dart';
 import '../config/oidc_config.dart';
 import 'auth_service.dart';
 import 'toast_service.dart';
@@ -69,6 +70,10 @@ class ApiClient {
   /// The configured Dio (auth + refresh interceptor, backend base URL) for
   /// requests the typed client doesn't cover well - e.g. binary downloads.
   Dio get dio => _dio;
+
+  /// Re-point at the current [BackendConfig.url] after it changes at runtime
+  /// (Settings -> Server), without recreating the client.
+  void applyBaseUrl() => _dio.options.baseUrl = BackendConfig.url;
 
   /// In-flight refresh, shared so concurrent 401s trigger a single token
   /// exchange instead of a stampede.

--- a/lib/services/school_systems_service.dart
+++ b/lib/services/school_systems_service.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 
+import '../config/backend_config.dart';
 import '../config/oidc_config.dart';
 import '../domain/school_system.dart';
 
@@ -17,6 +18,9 @@ class SchoolSystemsService {
     connectTimeout: const Duration(seconds: 10),
     receiveTimeout: const Duration(seconds: 15),
   ));
+
+  /// Re-point at the current [BackendConfig.url] after it changes at runtime.
+  static void applyBaseUrl() => _dio.options.baseUrl = BackendConfig.url;
 
   static Future<List<SchoolSystem>> fetch() async {
     final response = await _dio.get<List<dynamic>>('/api/app/school-systems');

--- a/lib/services/scrape_proxy_client.dart
+++ b/lib/services/scrape_proxy_client.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 
+import '../config/backend_config.dart';
 import '../config/oidc_config.dart';
 import '../domain/private_data.dart';
 import 'private_account_store.dart';
@@ -31,6 +32,9 @@ class ScrapeProxyClient {
     connectTimeout: const Duration(seconds: 10),
     receiveTimeout: const Duration(seconds: 90),
   ));
+
+  /// Re-point at the current [BackendConfig.url] after a runtime server change.
+  void applyBaseUrl() => _dio.options.baseUrl = BackendConfig.url;
 
   Future<ScrapeData> data(PrivateAccount account) async {
     final res = await _dio.post<Map<String, dynamic>>(

--- a/lib/services/token_proxy_client.dart
+++ b/lib/services/token_proxy_client.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 
+import '../config/backend_config.dart';
 import '../config/oidc_config.dart';
 import '../domain/private_data.dart';
 import 'private_account_store.dart';
@@ -21,6 +22,9 @@ class TokenProxyClient {
     connectTimeout: const Duration(seconds: 10),
     receiveTimeout: const Duration(seconds: 60),
   ));
+
+  /// Re-point at the current [BackendConfig.url] after a runtime server change.
+  void applyBaseUrl() => _dio.options.baseUrl = BackendConfig.url;
 
   // --- Auth ---
 

--- a/lib/ui/settings/settings_screen.dart
+++ b/lib/ui/settings/settings_screen.dart
@@ -2,14 +2,31 @@ import 'package:flutter/material.dart' show showLicensePage, ThemeMode;
 import 'package:flutter/widgets.dart';
 import 'package:forui/forui.dart';
 
+import '../../config/backend_config.dart';
+import '../../config/oidc_config.dart';
+import '../../services/active_account_service.dart';
+import '../../services/api_client.dart';
+import '../../services/auth_service.dart';
+import '../../services/private_account_store.dart';
+import '../../services/school_data_service.dart';
+import '../../services/school_systems_service.dart';
+import '../../services/scrape_proxy_client.dart';
 import '../../services/theme_service.dart';
+import '../../services/token_proxy_client.dart';
 
-/// App settings: appearance (theme mode) and open-source licenses.
-class SettingsScreen extends StatelessWidget {
+/// App settings: appearance, the backend server, and open-source licenses.
+class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
 
   @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  @override
   Widget build(BuildContext context) {
+    final server = BackendConfig.isCustom ? BackendConfig.url : 'Schuly Cloud';
+
     return FScaffold(
       header: FHeader.nested(
         title: const Text('Settings'),
@@ -41,6 +58,19 @@ class SettingsScreen extends StatelessWidget {
           ),
           const SizedBox(height: 20),
           FTileGroup(
+            label: const Text('Server'),
+            children: [
+              FTile(
+                prefix: const Icon(FIcons.server),
+                title: const Text('Backend server'),
+                subtitle: Text(server),
+                suffix: const Icon(FIcons.chevronRight),
+                onPress: _openServerDialog,
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          FTileGroup(
             label: const Text('About'),
             children: [
               FTile(
@@ -56,6 +86,177 @@ class SettingsScreen extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+
+  Future<void> _openServerDialog() async {
+    final changed = await showFDialog<bool>(
+      context: context,
+      builder: (ctx, style, animation) => _ServerDialog(animation: animation),
+    );
+    if (changed != true || !mounted) return;
+    // The session was cleared while switching backends; drop back to the root
+    // gate, which re-evaluates against the new server.
+    Navigator.of(context).popUntil((route) => route.isFirst);
+  }
+}
+
+/// Lets the user point the app at the hosted Schuly Cloud or a self-hosted
+/// backend. Saving re-points the HTTP clients, clears the OIDC cache, and signs
+/// out - a session and its data belong to one backend. Pops `true` on success.
+class _ServerDialog extends StatefulWidget {
+  final Animation<double> animation;
+  const _ServerDialog({required this.animation});
+
+  @override
+  State<_ServerDialog> createState() => _ServerDialogState();
+}
+
+class _ServerDialogState extends State<_ServerDialog> {
+  bool _custom = BackendConfig.isCustom;
+  late final _urlCtrl =
+      TextEditingController(text: BackendConfig.isCustom ? BackendConfig.url : '');
+  String? _error;
+  bool _busy = false;
+
+  @override
+  void dispose() {
+    _urlCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (_busy) return;
+    String? url; // null = hosted
+    if (_custom) {
+      final raw = _urlCtrl.text.trim();
+      final uri = Uri.tryParse(raw);
+      final valid = raw.isNotEmpty &&
+          uri != null &&
+          (uri.isScheme('http') || uri.isScheme('https')) &&
+          uri.host.isNotEmpty;
+      if (!valid) {
+        setState(() => _error = 'Enter a valid http(s) URL.');
+        return;
+      }
+      setState(() {
+        _busy = true;
+        _error = null;
+      });
+      final version = await BackendConfig.probe(raw);
+      if (!mounted) return;
+      if (version == null) {
+        setState(() {
+          _busy = false;
+          _error = "Couldn't reach a Schuly backend at this URL.";
+        });
+        return;
+      }
+      url = raw;
+    } else {
+      if (!BackendConfig.isCustom) {
+        // Already on hosted - nothing to change.
+        Navigator.of(context).pop(false);
+        return;
+      }
+      setState(() => _busy = true);
+    }
+
+    await BackendConfig.setUrl(url);
+    ApiClient.instance.applyBaseUrl();
+    SchoolSystemsService.applyBaseUrl();
+    TokenProxyClient.instance.applyBaseUrl();
+    ScrapeProxyClient.instance.applyBaseUrl();
+    OidcConfig.reset();
+    // Drop the now wrong-backend session + cached data.
+    await AuthService.signOut();
+    await PrivateAccountStore.instance.clear();
+    await ActiveAccountService.instance.clear();
+    SchoolDataService.instance.clear();
+    if (mounted) Navigator.of(context).pop(true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.theme.colors;
+    final typography = context.theme.typography;
+
+    Widget option(String label, String sub, bool selected, VoidCallback onTap) {
+      return GestureDetector(
+        onTap: _busy ? null : onTap,
+        behavior: HitTestBehavior.opaque,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                selected ? FIcons.circleCheck : FIcons.circle,
+                size: 20,
+                color: selected ? colors.primary : colors.mutedForeground,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(label,
+                        style: const TextStyle(fontWeight: FontWeight.w600)),
+                    Text(sub,
+                        style: typography.xs
+                            .copyWith(color: colors.mutedForeground)),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return FDialog(
+      animation: widget.animation,
+      title: const Text('Backend server'),
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          option('Schuly Cloud', 'The official Schuly server', !_custom,
+              () => setState(() {
+                    _custom = false;
+                    _error = null;
+                  })),
+          option('Self-hosted', 'Your own Schuly backend', _custom,
+              () => setState(() => _custom = true)),
+          if (_custom) ...[
+            const SizedBox(height: 10),
+            FTextField(
+              control: FTextFieldControl.managed(controller: _urlCtrl),
+              label: const Text('Backend URL'),
+              hint: 'https://schuly.example.com',
+              autocorrect: false,
+            ),
+          ],
+          if (_error != null) ...[
+            const SizedBox(height: 8),
+            Text(_error!, style: typography.sm.copyWith(color: colors.error)),
+          ],
+          const SizedBox(height: 12),
+          Text('Changing the server signs you out.',
+              style: typography.xs.copyWith(color: colors.mutedForeground)),
+        ],
+      ),
+      actions: [
+        FButton(
+          style: FButtonStyle.outline(),
+          onPress: _busy ? null : () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FButton(
+          onPress: _busy ? null : _save,
+          child: Text(_busy ? 'Checking...' : 'Save'),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
Settings now has a Server entry to switch between Schuly Cloud and a self-hosted backend (with the same reachability/version probe used in onboarding). Saving re-points the HTTP clients (ApiClient, catalog, proxy clients), clears the cached OIDC settings, and signs out - a session and its data belong to one backend - dropping back to the gate for the new server.

Closes #407