### PR TITLE
De-duplicated backend client re-pointing into a Dio factory

### DIFF
--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -1,9 +1,8 @@
 import 'package:dio/dio.dart';
 import 'package:schuly_api/schuly_api.dart';
 
-import '../config/backend_config.dart';
-import '../config/oidc_config.dart';
 import 'auth_service.dart';
+import 'backend_dio.dart';
 import 'toast_service.dart';
 
 /// Singleton-ish wrapper around the generated [SchulyApi]. Pre-wires the
@@ -13,12 +12,11 @@ class ApiClient {
   ApiClient._() {
     // The unified plugin login runs the initial sync inline, which takes well
     // over the generated client's 3s default on cold runs.
-    _dio = Dio(BaseOptions(
-      baseUrl: OidcConfig.backendBaseUrl,
+    _dio = backendDio(
       connectTimeout: const Duration(seconds: 10),
       receiveTimeout: const Duration(seconds: 120),
       sendTimeout: const Duration(seconds: 30),
-    ));
+    );
     api = SchulyApi(
       dio: _dio,
       interceptors: [
@@ -70,10 +68,6 @@ class ApiClient {
   /// The configured Dio (auth + refresh interceptor, backend base URL) for
   /// requests the typed client doesn't cover well - e.g. binary downloads.
   Dio get dio => _dio;
-
-  /// Re-point at the current [BackendConfig.url] after it changes at runtime
-  /// (Settings -> Server), without recreating the client.
-  void applyBaseUrl() => _dio.options.baseUrl = BackendConfig.url;
 
   /// In-flight refresh, shared so concurrent 401s trigger a single token
   /// exchange instead of a stampede.

--- a/lib/services/backend_dio.dart
+++ b/lib/services/backend_dio.dart
@@ -1,0 +1,22 @@
+import 'package:dio/dio.dart';
+
+import '../config/backend_config.dart';
+
+/// Builds a [Dio] whose base URL always tracks [BackendConfig.url]: an interceptor
+/// re-points it on every request, so a runtime backend change (Settings -> Server)
+/// takes effect immediately - no per-client `applyBaseUrl()` bookkeeping.
+Dio backendDio({Duration? connectTimeout, Duration? receiveTimeout, Duration? sendTimeout}) {
+  final dio = Dio(BaseOptions(
+    baseUrl: BackendConfig.url,
+    connectTimeout: connectTimeout,
+    receiveTimeout: receiveTimeout,
+    sendTimeout: sendTimeout,
+  ));
+  dio.interceptors.add(InterceptorsWrapper(
+    onRequest: (options, handler) {
+      options.baseUrl = BackendConfig.url;
+      handler.next(options);
+    },
+  ));
+  return dio;
+}

--- a/lib/services/school_systems_service.dart
+++ b/lib/services/school_systems_service.dart
@@ -1,8 +1,7 @@
 import 'package:dio/dio.dart';
 
-import '../config/backend_config.dart';
-import '../config/oidc_config.dart';
 import '../domain/school_system.dart';
+import 'backend_dio.dart';
 
 /// Fetches the backend-served catalog of school systems (anonymous endpoint).
 /// The backend is the **sole** source of truth for which systems exist and how
@@ -13,14 +12,10 @@ import '../domain/school_system.dart';
 /// this catalog and must never touch the authenticated Schuly stack. Throws if
 /// the catalog can't be reached; callers surface that to the user.
 class SchoolSystemsService {
-  static final Dio _dio = Dio(BaseOptions(
-    baseUrl: OidcConfig.backendBaseUrl,
+  static final Dio _dio = backendDio(
     connectTimeout: const Duration(seconds: 10),
     receiveTimeout: const Duration(seconds: 15),
-  ));
-
-  /// Re-point at the current [BackendConfig.url] after it changes at runtime.
-  static void applyBaseUrl() => _dio.options.baseUrl = BackendConfig.url;
+  );
 
   static Future<List<SchoolSystem>> fetch() async {
     final response = await _dio.get<List<dynamic>>('/api/app/school-systems');

--- a/lib/services/scrape_proxy_client.dart
+++ b/lib/services/scrape_proxy_client.dart
@@ -1,8 +1,7 @@
 import 'package:dio/dio.dart';
 
-import '../config/backend_config.dart';
-import '../config/oidc_config.dart';
 import '../domain/private_data.dart';
+import 'backend_dio.dart';
 import 'private_account_store.dart';
 
 /// Bundle returned by the stateless scrape proxy in one pass.
@@ -27,14 +26,10 @@ class ScrapeProxyClient {
   ScrapeProxyClient._();
   static final ScrapeProxyClient instance = ScrapeProxyClient._();
 
-  final Dio _dio = Dio(BaseOptions(
-    baseUrl: OidcConfig.backendBaseUrl,
+  final Dio _dio = backendDio(
     connectTimeout: const Duration(seconds: 10),
     receiveTimeout: const Duration(seconds: 90),
-  ));
-
-  /// Re-point at the current [BackendConfig.url] after a runtime server change.
-  void applyBaseUrl() => _dio.options.baseUrl = BackendConfig.url;
+  );
 
   Future<ScrapeData> data(PrivateAccount account) async {
     final res = await _dio.post<Map<String, dynamic>>(

--- a/lib/services/token_proxy_client.dart
+++ b/lib/services/token_proxy_client.dart
@@ -2,9 +2,8 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 
-import '../config/backend_config.dart';
-import '../config/oidc_config.dart';
 import '../domain/private_data.dart';
+import 'backend_dio.dart';
 import 'private_account_store.dart';
 import 'totp_service.dart';
 
@@ -17,14 +16,10 @@ class TokenProxyClient {
   TokenProxyClient._();
   static final TokenProxyClient instance = TokenProxyClient._();
 
-  final Dio _dio = Dio(BaseOptions(
-    baseUrl: OidcConfig.backendBaseUrl,
+  final Dio _dio = backendDio(
     connectTimeout: const Duration(seconds: 10),
     receiveTimeout: const Duration(seconds: 60),
-  ));
-
-  /// Re-point at the current [BackendConfig.url] after a runtime server change.
-  void applyBaseUrl() => _dio.options.baseUrl = BackendConfig.url;
+  );
 
   // --- Auth ---
 

--- a/lib/ui/settings/settings_screen.dart
+++ b/lib/ui/settings/settings_screen.dart
@@ -5,14 +5,10 @@ import 'package:forui/forui.dart';
 import '../../config/backend_config.dart';
 import '../../config/oidc_config.dart';
 import '../../services/active_account_service.dart';
-import '../../services/api_client.dart';
 import '../../services/auth_service.dart';
 import '../../services/private_account_store.dart';
 import '../../services/school_data_service.dart';
-import '../../services/school_systems_service.dart';
-import '../../services/scrape_proxy_client.dart';
 import '../../services/theme_service.dart';
-import '../../services/token_proxy_client.dart';
 
 /// App settings: appearance, the backend server, and open-source licenses.
 class SettingsScreen extends StatefulWidget {
@@ -163,10 +159,8 @@ class _ServerDialogState extends State<_ServerDialog> {
     }
 
     await BackendConfig.setUrl(url);
-    ApiClient.instance.applyBaseUrl();
-    SchoolSystemsService.applyBaseUrl();
-    TokenProxyClient.instance.applyBaseUrl();
-    ScrapeProxyClient.instance.applyBaseUrl();
+    // The HTTP clients re-point themselves at BackendConfig.url per request; just
+    // reset the cached OIDC settings so the new backend's authority is re-fetched.
     OidcConfig.reset();
     // Drop the now wrong-backend session + cached data.
     await AuthService.signOut();


### PR DESCRIPTION
Added a backendDio() factory whose interceptor re-points the base URL to BackendConfig.url on every request, and routed all four backend HTTP clients through it. This removes the four duplicated applyBaseUrl() methods and the four calls in the settings server dialog - a runtime server change now takes effect automatically.

Closes #415