### PR TITLE
Fixed school-system picker card overflow by sizing to content

### DIFF
--- a/lib/ui/dashboard/widgets/add_school_modal.dart
+++ b/lib/ui/dashboard/widgets/add_school_modal.dart
@@ -129,7 +129,6 @@ class _SystemCard extends StatelessWidget {
       opacity: disabled ? 0.5 : 1.0,
       child: SizedBox(
         width: 108,
-        height: 96,
         child: FTappable(
           onPress: onTap,
           child: FCard(


### PR DESCRIPTION
Removed the fixed 96px height on _SystemCard so it sizes to its content, fixing the bottom RenderFlex overflow that clipped the system label.

Closes #425