### PR TITLE
Removed redundant card wrapper around the TOTP picker tile

### DIFF
--- a/lib/ui/authenticator/totp_field_picker.dart
+++ b/lib/ui/authenticator/totp_field_picker.dart
@@ -110,14 +110,12 @@ class _TotpFieldPickerState extends State<TotpFieldPicker> {
     final subtitle = selected == null
         ? 'Not set — tap to choose'
         : [selected.title, if (selected.subtitle != null) selected.subtitle].join(' · ');
-    return FCard(
-      child: FTile(
-        prefix: const Icon(FIcons.shieldCheck),
-        title: Text(widget.field.label),
-        subtitle: Text(subtitle, style: selected == null ? TextStyle(color: colors.mutedForeground) : null),
-        suffix: const Icon(FIcons.chevronRight),
-        onPress: _openMenu,
-      ),
+    return FTile(
+      prefix: const Icon(FIcons.shieldCheck),
+      title: Text(widget.field.label),
+      subtitle: Text(subtitle, style: selected == null ? TextStyle(color: colors.mutedForeground) : null),
+      suffix: const Icon(FIcons.chevronRight),
+      onPress: _openMenu,
     );
   }
 }


### PR DESCRIPTION
## Summary
The TOTP picker wrapped an `FTile` (which already has its own border) inside an `FCard`, producing a card-in-a-card on connect screens. Dropped the `FCard`.

Closes #433