### PR TITLE
Shortened TOTP picker hint to "Tap to choose"

### DIFF
--- a/lib/ui/authenticator/totp_field_picker.dart
+++ b/lib/ui/authenticator/totp_field_picker.dart
@@ -108,7 +108,7 @@ class _TotpFieldPickerState extends State<TotpFieldPicker> {
     final colors = context.theme.colors;
     final selected = _selected;
     final subtitle = selected == null
-        ? 'Not set — tap to choose'
+        ? 'Tap to choose'
         : [selected.title, if (selected.subtitle != null) selected.subtitle].join(' · ');
     return FTile(
       prefix: const Icon(FIcons.shieldCheck),


### PR DESCRIPTION
## Summary
Dropped the "Not set —" prefix on the connect-screen 2FA picker's unselected hint; it now reads just "Tap to choose".

Closes #435