### PR TITLE
Point the README at the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <p align="center">
   <a href="https://github.com/schulydev/Schuly/stargazers"><img src="https://img.shields.io/github/stars/schulydev/Schuly?style=flat&color=3da8ff" alt="GitHub stars"/></a>
   <a href="https://github.com/schulydev/Schuly/releases"><img src="https://img.shields.io/github/v/release/schulydev/Schuly?include_prereleases&color=3da8ff&label=Release" alt="Latest Release"/></a>
+  <a href="https://docs.schuly.dev/Schuly/"><img src="https://img.shields.io/badge/docs-docs.schuly.dev-3da8ff" alt="Documentation"/></a>
   <a href="https://schuly.dev"><img src="https://img.shields.io/badge/site-schuly.dev-3da8ff" alt="Website"/></a>
 </p>
 
@@ -16,59 +17,43 @@ A modern Flutter mobile app providing a superior alternative to the official Sch
 > [!IMPORTANT]
 > This project is **NOT** affiliated with, endorsed by, or connected to Schulnetz or Centerboard AG in any way.
 
-## The Schuly ecosystem
+## Quick start
 
-| Repo | Purpose |
-|---|---|
-| [**Schuly**](https://github.com/schulydev/Schuly) | Flutter mobile app *(this repo)* |
-| [**SchulyBackend**](https://github.com/schulydev/SchulyBackend) | ASP.NET Core API backend |
-| [**SchulyPluginAbstractions**](https://github.com/schulydev/SchulyPluginAbstractions) | Plugin contract (NuGet) |
-| [**SchulyPlugins**](https://github.com/schulydev/SchulyPlugins) | Official plugins monorepo |
-| [**SchulyWebsite**](https://github.com/schulydev/SchulyWebsite) | Landing site ([schuly.dev](https://schuly.dev)) |
-
-## Run / build
-
-Common workflows are wrapped as [bun](https://bun.sh) scripts (bun is only the task runner - it doesn't pull in a Node toolchain), so they run the same way from any shell:
+Common workflows are wrapped as [bun](https://bun.sh) scripts (bun is only the task runner - it doesn't pull in a Node toolchain):
 
 ```sh
 bun run dev               # flutter run, dev flavor
 bun run prod              # flutter run, prod flavor
 bun run analyze           # flutter analyze
 bun run test              # flutter test
-bun run format            # dart format lib
-bun run build:apk:dev     # release APK, dev flavor
-bun run build:apk:prod    # release APK, prod flavor
-bun run build:ios         # iOS build (no codesign)
-bun run icons             # regenerate launcher icons
-bun run clean             # flutter clean && pub get
 ```
 
 Flavors: `dev` (`com.schuly.app.dev`, "Schuly DEV") and `prod` (`com.schuly.app`, "Schuly"). Targets Android and iOS only.
 
-## Connecting to a local backend (dev)
+The backend URL is compiled in via `--dart-define=BACKEND_BASE_URL` and defaults to `http://localhost:5033`, so no machine IP is ever committed. [Development setup](https://docs.schuly.dev/Schuly/setup/development) covers the full script list, the build variants, and pointing the app at a local backend over USB or LAN.
 
-The backend URL is compiled in via `--dart-define=BACKEND_BASE_URL` and defaults to `http://localhost:5033` - no machine IP is ever committed.
+## Documentation
 
-```sh
-# USB device → run the backend on the host, tunnel, build + install:
-bun run install:dev:usb     # = adb reverse tcp:5033 tcp:5033 + install:dev
+Full documentation lives at **[docs.schuly.dev/Schuly](https://docs.schuly.dev/Schuly/)**.
 
-# Same network / wireless → point at the host's LAN IP explicitly:
-BACKEND_BASE_URL=http://<dev-box-lan-ip>:5033 bun run install:dev:url
-```
+| Guide | What it covers |
+|---|---|
+| [Development setup](https://docs.schuly.dev/Schuly/setup/development) | Prerequisites, bun tasks, flavors, and connecting to a local backend. |
+| [Build and release](https://docs.schuly.dev/Schuly/setup/build-and-release) | Release builds for Android and iOS, and how a release is cut. |
+| [Architecture modes](https://docs.schuly.dev/Schuly/architecture-modes) | Account mode vs private mode, and how each reaches school data. |
+| [API client](https://docs.schuly.dev/Schuly/api-client) | Regenerating the Dart client from the backend's OpenAPI document. |
+| [Contributing](https://docs.schuly.dev/Schuly/contributing) | Workflow, branch and PR conventions. |
 
-(`bun run install:dev` / `install:prod` build + install with the defaults; `bun run adb:reverse` just sets up the tunnel.)
+New to Schuly as a user? Start with the [getting-started walkthrough](https://docs.schuly.dev/getting-started/).
 
-## Regenerate the API client
+## The Schuly ecosystem
 
-The Dart client at `lib/api/` is generated from [SchulyBackend](https://github.com/schulydev/SchulyBackend)'s OpenAPI spec:
-
-```sh
-bun run apigen             # against http://localhost:5033 (live backend)
-```
-
-`openapi.json` is never committed - always regenerate from a running backend. See `CLAUDE.md` for details.
-
-## App icons
-
-Source: `assets/app_icon.png`. Regenerate with `bun run icons`.
+| Repo | Purpose |
+|---|---|
+| [**Schuly**](https://github.com/schulydev/Schuly) | Flutter mobile app *(this repo)* |
+| [**SchulyBackend**](https://github.com/schulydev/SchulyBackend) | ASP.NET Core API backend |
+| [**SchulyKeycloak**](https://github.com/schulydev/SchulyKeycloak) | Keycloak image + the `schuly` realm |
+| [**SchulyPluginAbstractions**](https://github.com/schulydev/SchulyPluginAbstractions) | Plugin contract (NuGet) |
+| [**SchulyPlugins**](https://github.com/schulydev/SchulyPlugins) | Official plugins monorepo |
+| [**SchulyWebsite**](https://github.com/schulydev/SchulyWebsite) | Landing site ([schuly.dev](https://schuly.dev)) |
+| [**SchulyDocs**](https://github.com/schulydev/SchulyDocs) | Documentation site ([docs.schuly.dev](https://docs.schuly.dev)) |


### PR DESCRIPTION
The README carried setup material that [docs.schuly.dev](https://docs.schuly.dev) now owns, so the same instructions were maintained in two places. The duplicated sections are trimmed to a short quick start, every remaining topic links to its own page on the docs site, and the ecosystem table lists all seven repos including SchulyKeycloak and SchulyDocs.

Every docs.schuly.dev link in the file was checked and returns 200.

Closes #443