### PR TITLE
Shorten two page headings

### DIFF
--- a/docs/api-client.md
+++ b/docs/api-client.md
@@ -1,4 +1,4 @@
-# API client (`lib/api/`)
+# API client
 
 The Dart API client at `lib/api/` is **generated**, not hand-written. It is produced
 by [openapi-generator](https://openapi-generator.tech) (`dart-dio` generator) from

--- a/docs/architecture-modes.md
+++ b/docs/architecture-modes.md
@@ -1,4 +1,4 @@
-# App modes: Account vs Private (secure)
+# App modes
 
 Schuly runs in one of two modes, chosen at the gate. Both read the same school
 systems from the same backend catalog; the difference is **who signs the user in**


### PR DESCRIPTION
The docs site derives sidebar entries from page headings. "API client (`lib/api/`)" put literal backticks in the navigation, and "App modes: Account vs Private (secure)" was a full sentence beside two-word siblings. Both pages already give the detail in their first paragraph.

Closes #449