### PR TITLE
Let password managers see the login fields

### DIFF
--- a/lib/ui/account/unified_connect_screen.dart
+++ b/lib/ui/account/unified_connect_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:forui/forui.dart';
 
 import '../../domain/school_system.dart';
@@ -61,6 +62,9 @@ class _UnifiedConnectScreenState extends State<UnifiedConnectScreen> {
         options: ApiClient.handled(),
       );
       final accountId = res.data?['accountId']?.toString();
+      // Only once the credentials are known good, so a manager is never asked
+      // to save something that did not work.
+      TextInput.finishAutofillContext();
       if (mounted) Navigator.of(context).pop(accountId);
     } catch (e) {
       setState(() => _error = ApiError.describe(e));

--- a/lib/ui/private/private_connect_screen.dart
+++ b/lib/ui/private/private_connect_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:forui/forui.dart';
 
 import '../../domain/school_system.dart';
@@ -102,6 +103,7 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
       password: password,
       totpSecret: totpSecret,
     ));
+    TextInput.finishAutofillContext();
     if (mounted) Navigator.of(context).pop(true);
   }
 
@@ -118,6 +120,7 @@ class _PrivateConnectScreenState extends State<PrivateConnectScreen> {
     );
     await ScrapeProxyClient.instance.data(account);
     await PrivateAccountStore.instance.save(account);
+    TextInput.finishAutofillContext();
     if (mounted) Navigator.of(context).pop(true);
   }
 

--- a/lib/ui/widgets/dynamic_login_form.dart
+++ b/lib/ui/widgets/dynamic_login_form.dart
@@ -45,33 +45,60 @@ class DynamicLoginForm extends StatelessWidget {
   static bool _isTotp(SchoolSystemLoginField f) =>
       f.type == 'totp' || f.key.toLowerCase() == 'totp';
 
+  /// What the platform needs to tell these boxes apart. The form is built from
+  /// the catalog, so this reads the descriptor rather than naming any school
+  /// system; without it a password manager sees a row of anonymous text boxes
+  /// and offers nothing.
+  static List<String> _autofillHints(SchoolSystemLoginField f) {
+    final key = f.key.toLowerCase();
+    if (f.type == 'password' || key.contains('password')) return const [AutofillHints.password];
+    if (f.type == 'url' || key.contains('url')) return const [AutofillHints.url];
+    if (f.type == 'email' || key.contains('email') || key.contains('mail')) {
+      return const [AutofillHints.username, AutofillHints.email];
+    }
+    if (key.contains('user') || key.contains('login')) return const [AutofillHints.username];
+    return const [];
+  }
+
+  static TextInputType _keyboard(SchoolSystemLoginField f) {
+    final key = f.key.toLowerCase();
+    if (f.type == 'url' || key.contains('url')) return TextInputType.url;
+    if (f.type == 'email' || key.contains('email') || key.contains('mail')) return TextInputType.emailAddress;
+    return TextInputType.text;
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      mainAxisSize: MainAxisSize.min,
-      spacing: 16,
-      children: [
-        for (final field in controller.fields)
-          if (_isTotp(field))
-            TotpFieldPicker(
-              controller: controller.controllerFor(field.key),
-              field: field,
-            )
-          else
-            FTextField(
-              control: FTextFieldControl.managed(
+    final fields = controller.fields;
+    // One group, so the platform treats the boxes as a single credential rather
+    // than unrelated inputs.
+    return AutofillGroup(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        spacing: 16,
+        children: [
+          for (final (index, field) in fields.indexed)
+            if (_isTotp(field))
+              TotpFieldPicker(
                 controller: controller.controllerFor(field.key),
+                field: field,
+              )
+            else
+              FTextField(
+                control: FTextFieldControl.managed(
+                  controller: controller.controllerFor(field.key),
+                ),
+                label: Text(field.label),
+                hint: field.placeholder,
+                obscureText: field.type == 'password',
+                keyboardType: _keyboard(field),
+                textInputAction: index == fields.length - 1 ? TextInputAction.done : TextInputAction.next,
+                autofillHints: _autofillHints(field),
+                autocorrect: false,
               ),
-              label: Text(field.label),
-              hint: field.placeholder,
-              obscureText: field.type == 'password',
-              keyboardType: field.type == 'url'
-                  ? TextInputType.url
-                  : TextInputType.text,
-              autocorrect: false,
-            ),
-      ],
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
Every field in the connect form was a plain `FTextField` with no autofill information, so the platform had nothing to classify them by and managers offered neither fill nor save.

Each field now gets hints derived from its catalog descriptor rather than from any hardcoded school system: password, url, username plus email, or username, keyed off `type` first and the field `key` second. The email box also gets `TextInputType.emailAddress` instead of plain text, and the form chains next/done through its fields.

The fields are wrapped in an `AutofillGroup` so the platform reads them as one credential, and `TextInput.finishAutofillContext()` runs after a connect succeeds - never after a failure, so nothing is offered for saving that did not work. The 2FA row is a picker rather than a text field, so it is left out.

Checked on the emulator with Google's autofill service active: focusing the email box now produces an autofill request for that field's bounds, dispatched to `com.google.android.gms`. The same action on the previous build produced no autofill entry at all.

What this cannot show is an actual fill or save prompt - that needs credentials already stored for the app in a manager, which a fresh emulator has none of. Flutter's save prompt is also known to be inconsistent across services ([flutter#104071](https://github.com/flutter/flutter/issues/104071)).

Closes #456