### PR TITLE
Link the setup guide from the Authenticator screen

### DIFF
--- a/lib/ui/authenticator/authenticator_vault_screen.dart
+++ b/lib/ui/authenticator/authenticator_vault_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:forui/forui.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../services/private_account_store.dart';
 import '../../services/totp_service.dart';
@@ -72,6 +73,13 @@ class _AuthenticatorVaultScreenState extends State<AuthenticatorVaultScreen> {
       MaterialPageRoute(builder: (_) => const AddTotpScreen()),
     );
     if (added != null) await _load();
+  }
+
+  Future<void> _openGuide() async {
+    await launchUrl(
+      Uri.parse('https://docs.schuly.dev/getting-started/authenticator'),
+      mode: LaunchMode.externalApplication,
+    );
   }
 
   Future<void> _copy(String? code) async {
@@ -149,6 +157,13 @@ class _AuthenticatorVaultScreenState extends State<AuthenticatorVaultScreen> {
             ),
             const SizedBox(height: 24),
             FButton(prefix: const Icon(FIcons.plus), onPress: _add, child: const Text('Add authenticator')),
+            const SizedBox(height: 12),
+            FButton(
+              style: FButtonStyle.ghost(),
+              prefix: const Icon(FIcons.bookOpen),
+              onPress: _openGuide,
+              child: const Text('How do I set this up?'),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
Adds a "How do I set this up?" action to the Authenticator empty state, opening the guide at docs.schuly.dev. The screen previously told people to scan the QR code shown when setting up two-factor authentication, without saying where that comes from or that a second screen is needed to scan it.

Closes #462