### PR TITLE
Set the version files to the released version

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <properties>
-    <version>1.0.0</version>
+    <version>2.7.0</version>
 </properties>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 2.7.0+1
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Both files read `1.0.0` while the latest release is `v2.7.0`, so `version-bump.yml` would compute the next version from `1.0.0` and tag behind the current release. Set both to `2.7.0`, keeping the `+1` build suffix.

Closes #466