### PR TITLE
Map birthday and entry date in the private-mode adapter

### DIFF
--- a/lib/api/.openapi-generator/FILES
+++ b/lib/api/.openapi-generator/FILES
@@ -145,4 +145,3 @@ lib/src/model/user_class_dto.dart
 lib/src/model/user_state.dart
 lib/src/serializers.dart
 pubspec.yaml
-test/install_plugin_request_test.dart

--- a/lib/api/README.md
+++ b/lib/api/README.md
@@ -193,7 +193,7 @@ Authentication schemes defined for the API:
 
 - **Type**: OAuth
 - **Flow**: accessCode
-- **Authorization URL**: http://localhost:8080/realms/polyglot/authorize
+- **Authorization URL**: https://auth.gaggao.com/authorize
 - **Scopes**: 
  - **openid**: OpenID Connect
  - **profile**: User profile

--- a/lib/api/doc/SchoolUserDto.md
+++ b/lib/api/doc/SchoolUserDto.md
@@ -21,8 +21,8 @@ Name | Type | Description | Notes
 **street** | **String** |  | [optional] 
 **city** | **String** |  | [optional] 
 **zip** | **String** |  | [optional] 
-**birthday** | [**Date**](Date.md) |  | 
-**entryDate** | [**Date**](Date.md) |  | 
+**birthday** | [**Date**](Date.md) |  | [optional] 
+**entryDate** | [**Date**](Date.md) |  | [optional] 
 **leaveDate** | [**Date**](Date.md) |  | [optional] 
 **role** | [**Roles**](Roles.md) |  | 
 **state** | [**UserState**](UserState.md) |  | [optional] 

--- a/lib/api/lib/src/model/school_user_dto.dart
+++ b/lib/api/lib/src/model/school_user_dto.dart
@@ -83,10 +83,10 @@ abstract class SchoolUserDto implements Built<SchoolUserDto, SchoolUserDtoBuilde
   String? get zip;
 
   @BuiltValueField(wireName: r'birthday')
-  Date get birthday;
+  Date? get birthday;
 
   @BuiltValueField(wireName: r'entryDate')
-  Date get entryDate;
+  Date? get entryDate;
 
   @BuiltValueField(wireName: r'leaveDate')
   Date? get leaveDate;
@@ -222,16 +222,20 @@ class _$SchoolUserDtoSerializer implements PrimitiveSerializer<SchoolUserDto> {
         specifiedType: const FullType.nullable(String),
       );
     }
-    yield r'birthday';
-    yield serializers.serialize(
-      object.birthday,
-      specifiedType: const FullType(Date),
-    );
-    yield r'entryDate';
-    yield serializers.serialize(
-      object.entryDate,
-      specifiedType: const FullType(Date),
-    );
+    if (object.birthday != null) {
+      yield r'birthday';
+      yield serializers.serialize(
+        object.birthday,
+        specifiedType: const FullType.nullable(Date),
+      );
+    }
+    if (object.entryDate != null) {
+      yield r'entryDate';
+      yield serializers.serialize(
+        object.entryDate,
+        specifiedType: const FullType.nullable(Date),
+      );
+    }
     if (object.leaveDate != null) {
       yield r'leaveDate';
       yield serializers.serialize(
@@ -410,15 +414,17 @@ class _$SchoolUserDtoSerializer implements PrimitiveSerializer<SchoolUserDto> {
         case r'birthday':
           final valueDes = serializers.deserialize(
             value,
-            specifiedType: const FullType(Date),
-          ) as Date;
+            specifiedType: const FullType.nullable(Date),
+          ) as Date?;
+          if (valueDes == null) continue;
           result.birthday = valueDes;
           break;
         case r'entryDate':
           final valueDes = serializers.deserialize(
             value,
-            specifiedType: const FullType(Date),
-          ) as Date;
+            specifiedType: const FullType.nullable(Date),
+          ) as Date?;
+          if (valueDes == null) continue;
           result.entryDate = valueDes;
           break;
         case r'leaveDate':

--- a/lib/api/lib/src/model/school_user_dto.g.dart
+++ b/lib/api/lib/src/model/school_user_dto.g.dart
@@ -34,9 +34,9 @@ class _$SchoolUserDto extends SchoolUserDto {
   @override
   final String? zip;
   @override
-  final Date birthday;
+  final Date? birthday;
   @override
-  final Date entryDate;
+  final Date? entryDate;
   @override
   final Date? leaveDate;
   @override
@@ -71,8 +71,8 @@ class _$SchoolUserDto extends SchoolUserDto {
     this.street,
     this.city,
     this.zip,
-    required this.birthday,
-    required this.entryDate,
+    this.birthday,
+    this.entryDate,
     this.leaveDate,
     required this.role,
     this.state,
@@ -359,16 +359,8 @@ class SchoolUserDtoBuilder
             street: street,
             city: city,
             zip: zip,
-            birthday: BuiltValueNullFieldError.checkNotNull(
-              birthday,
-              r'SchoolUserDto',
-              'birthday',
-            ),
-            entryDate: BuiltValueNullFieldError.checkNotNull(
-              entryDate,
-              r'SchoolUserDto',
-              'entryDate',
-            ),
+            birthday: birthday,
+            entryDate: entryDate,
             leaveDate: leaveDate,
             role: BuiltValueNullFieldError.checkNotNull(
               role,

--- a/lib/services/private_data_adapter.dart
+++ b/lib/services/private_data_adapter.dart
@@ -11,6 +11,11 @@ class PrivateDataAdapter {
 
   static DateTime _dateOr(String? s, DateTime fallback) => _date(s) ?? fallback;
 
+  static Date? _dateOnly(String? s) {
+    final d = _date(s);
+    return d == null ? null : Date(d.year, d.month, d.day);
+  }
+
   static GradeDto grade(PrivateGrade g) => GradeDto((b) => b
     ..id = g.id
     ..score = g.score
@@ -56,6 +61,8 @@ class PrivateDataAdapter {
         ..firstName = info?.firstName ?? ''
         ..lastName = info?.lastName ?? ''
         ..email = info?.email ?? ''
+        ..birthday = _dateOnly(info?.birthday)
+        ..entryDate = _dateOnly(info?.entryDate)
         ..role = Roles.student
         ..grades = ListBuilder<GradeDto>(grades.map(grade))
         ..absences = ListBuilder<AbsenceDto>(absences.map(absence)));


### PR DESCRIPTION
Private mode built `SchoolUserDto` without ever setting `birthday` or `entryDate`, while the generated model declared both non-nullable, so `build()` threw on every private-mode load regardless of the data. `PrivateUserInfo` already carried both values from the stateless endpoint; they were simply never mapped.

Regenerated the API client against a spec where `SchoolUserDto.Birthday` / `EntryDate` are nullable, and mapped the values through in `PrivateDataAdapter`. A Schulnetz account with no birthday now renders as `-`, which `account_page.dart` already handled.

Closes #473